### PR TITLE
Fixes rendering of extraContainers on api's setup jobs

### DIFF
--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -108,7 +108,7 @@ spec:
         envFrom: 
 {{ toYaml .Values.envFrom | indent 10 }}
 {{- with .Values.extraContainers }}
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- else }}
       # Write an empty container to avoid a syntax error
@@ -171,7 +171,7 @@ spec:
 {{ toYaml .Values.envFrom | nindent 10 }}
 {{- end }}
 {{- with .Values.extraContainers }}
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hatchet-frontend/Chart.yaml
+++ b/charts/hatchet-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-frontend
 description: A Helm chart for deploying a frontend static file server on Kubernetes.
 type: application
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.8.0
+  version: 0.8.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 14.3.3

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run
@@ -10,27 +10,27 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.8.0
+  version: 0.8.1
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.8.0
+  version: 0.8.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 14.3.3

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes together with a PostgreSQL database and RabbitMQ.
 type: application
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run
@@ -10,17 +10,17 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "^0.8.0"
+    version: "^0.8.1"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled


### PR DESCRIPTION
Trying to set extraContainers on api causes the following error:
```
Error: YAML parse error on hatchet-stack/charts/api/templates/setup-job.yaml: error converting YAML to JSON: yaml: line 67: did not find expected key
```

Reproduction values file:
```yaml
api:
  extraContainers:
    - name: foo
```


```bash
helm template foo hatchet/hatchet-stack -f tmp.yaml
```
