### PR TITLE
Add image repo and tag overrides where hardcoded

### DIFF
--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -140,7 +140,7 @@ spec:
       {{- end }}
       initContainers:
       - name: check-db-connection
-        image: postgres:latest
+        image: "{{ .Values.workerTokenJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.workerTokenJob.image.tag }}"
         command: ['sh', '-c', 'until pg_isready -d $DATABASE_URL; do echo waiting for database; sleep 2; done;']
         env:
         {{- range $key, $value := .Values.env }}

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -29,6 +29,10 @@ quickstartJob:
 
 workerTokenJob:
   enabled: true
+  image:
+    repository: "postgres"
+    tag: "latest"
+    pullPolicy: "Always"
 
 commandline:
   command: ["/hatchet/hatchet-api"]

--- a/charts/hatchet-ha/templates/caddy.yaml
+++ b/charts/hatchet-ha/templates/caddy.yaml
@@ -43,7 +43,8 @@ spec:
     spec:
       containers:
       - name: caddy
-        image: caddy:2.7.6-alpine
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -216,3 +216,7 @@ rabbitmq:
 
 caddy:
   enabled: false
+  image:
+    repository: "caddy"
+    tag: "2.7.6-alpine"
+    pullPolicy: "Always"

--- a/charts/hatchet-stack/templates/caddy.yaml
+++ b/charts/hatchet-stack/templates/caddy.yaml
@@ -43,7 +43,8 @@ spec:
     spec:
       containers:
       - name: caddy
-        image: caddy:2.7.6-alpine
+        image: "{{ .Values.image.repository }}:{{ required "Please set a value for .Values.image.tag" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -129,3 +129,7 @@ rabbitmq:
 
 caddy:
   enabled: false
+  image:
+    repository: "caddy"
+    tag: "2.7.6-alpine"
+    pullPolicy: "Always"


### PR DESCRIPTION
In enterprise configurations you may not be able to pull from dockerhub or public container registries. Give the ability to chart consumers to specify the image repository if needed. 