### PR TITLE
Allow extra ports to be specified for service and deployment resources

### DIFF
--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
           name: {{ template "hatchet.name" . }}
           protocol: TCP
+{{- if .Values.deployment.extraPorts }}
+{{ toYaml .Values.deployment.extraPorts | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/charts/hatchet-api/templates/service.yaml
+++ b/charts/hatchet-api/templates/service.yaml
@@ -34,6 +34,9 @@ spec:
 {{- if .Values.service.portName }}
       name: {{ .Values.service.portName }}
 {{- end }}
+{{- if .Values.service.extraPorts }}
+{{ toYaml .Values.service.extraPorts | indent 4 }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -60,6 +60,7 @@ deployment:
   annotations:
     app.kubernetes.io/name: hatchet-api
   labels: {}
+  extraPorts: []
 
 persistence:
   size: 5Gi
@@ -80,6 +81,7 @@ service:
   # loadBalancerSourceRanges: []
   selector: {}
   # portName: service-port
+  extraPorts: []
 
 ingress:
   enabled: true


### PR DESCRIPTION
This change introduces the ability to specify additional ports for both the deployment and service resources in the hatchet-api Helm chart, providing greater flexibility for applications that need to expose multiple ports. This is useful for instance to enable [Prometheus metrics](https://docs.hatchet.run/self-hosting/prometheus-metrics).

This change is fully backward compatible. Existing deployments will continue to work unchanged, as the extra ports configuration is optional and only applied when specified.

