### PR TITLE
feat: add PSA restricted compliance — securityContext, remove SYS_PTRACE

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `podSecurityContext` and `containerSecurityContext` values for Kubernetes Pod Security Standards compliance.
+- `shareProcessNamespace` as a configurable value (default: `true` for backward compatibility).
+
+### Removed
+- Hardcoded `SYS_PTRACE` capability from migration, seed, and setup job containers.
+
+### Changed
+- Init container (`check-db-connection`) security context is now values-driven, matching other containers.
+
 ## [0.10.4] - 2026-03-11
 
 - Updates the default Hatchet image to [`v0.79.12`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.79.12).

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
+          capabilities:
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
         - name: "{{ $key }}"
@@ -114,6 +123,13 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- else }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -118,9 +118,11 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else if .Values.podSecurityContext }}
+{{- else }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -49,15 +49,10 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
         - name: "{{ $key }}"
@@ -123,13 +118,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else }}
+{{- else if .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -46,12 +46,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- if .Values.migrationJob.enabled }}
       - name: check-db-connection
@@ -81,15 +79,10 @@ spec:
       - name: migration-job
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -106,15 +99,10 @@ spec:
         imagePullPolicy: {{ .Values.seedJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "quickstart", "--skip", "certs", "--skip", "keys"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: SERVER_DEFAULT_ENGINE_VERSION
             value: "V1"
@@ -137,15 +125,10 @@ spec:
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "quickstart", "--namespace", "{{ .Release.Namespace }}", "--overwrite=false"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -183,12 +166,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
@@ -220,15 +201,10 @@ spec:
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "create-worker-token", "--namespace", "{{ .Release.Namespace }}"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -46,6 +46,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -67,11 +68,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
       {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
 {{ toYaml .Values.envFrom | indent 10 }}
 
@@ -166,6 +166,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -185,11 +186,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
 {{ toYaml .Values.deploymentEnvFrom | nindent 10 }}
 {{- if .Values.envFrom }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -143,6 +143,10 @@ spec:
       - name: empty
         image: "alpine:3.14"
         command: ["sh", "-c", "echo 'No setup job configured'"]
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 ---
 {{- if .Values.workerTokenJob.enabled }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -42,11 +42,16 @@ spec:
 {{- include "hatchet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       initContainers:
       {{- if .Values.migrationJob.enabled }}
       - name: check-db-connection
@@ -64,6 +69,11 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
       {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         envFrom:
 {{ toYaml .Values.envFrom | indent 10 }}
 
@@ -72,9 +82,14 @@ spec:
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -92,9 +107,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "quickstart", "--skip", "certs", "--skip", "keys"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
           - name: SERVER_DEFAULT_ENGINE_VERSION
             value: "V1"
@@ -118,9 +138,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "quickstart", "--namespace", "{{ .Release.Namespace }}", "--overwrite=false"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -154,11 +179,16 @@ spec:
 {{- include "hatchet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       initContainers:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
@@ -174,6 +204,11 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         envFrom:
 {{ toYaml .Values.deploymentEnvFrom | nindent 10 }}
 {{- if .Values.envFrom }}
@@ -186,9 +221,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "create-worker-token", "--namespace", "{{ .Release.Namespace }}"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -160,12 +160,32 @@ revisionHistoryLimit: 3
 # podDisruptionBudget:
 #   maxUnavailable: 1
 
-# default security context
+# Legacy security context (deprecated — use podSecurityContext instead)
+# Kept for backward compatibility with existing values overrides
 securityContext:
   enabled: false
   allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+
+# Pod-level security context (applied to all pods)
+# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
+# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 0
+  seccompProfileType: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfileType: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -178,9 +178,12 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+shareProcessNamespace: false
+
 # Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem defaults to false because upstream hatchet images write to the filesystem
   readOnlyRootFilesystem: false
   capabilities:
     drop:

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -178,7 +178,8 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-shareProcessNamespace: false
+# Kept as true for backward compatibility. Set to false for PSA restricted compliance.
+shareProcessNamespace: true
 
 # Container-level security context (applied to each container)
 containerSecurityContext:

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -169,28 +169,31 @@ securityContext:
   fsGroup: 2000
 
 # Pod-level security context (applied to the pod spec)
-# Default only sets seccompProfile. To run as non-root, add:
-#   runAsNonRoot: true
-#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
-#   runAsGroup: 1000
-#   fsGroup: 1000
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   podSecurityContext:
+#     runAsNonRoot: true
+#     runAsUser: 1000
+#     runAsGroup: 1000
+#     fsGroup: 1000
+#     seccompProfile:
+#       type: RuntimeDefault
+podSecurityContext: {}
 
+# Share process namespace between containers in job pods.
 # Kept as true for backward compatibility. Set to false for PSA restricted compliance.
 shareProcessNamespace: true
 
 # Container-level security context (applied to each container)
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  # readOnlyRootFilesystem defaults to false because upstream hatchet images write to the filesystem
-  readOnlyRootFilesystem: false
-  capabilities:
-    drop:
-      - ALL
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     readOnlyRootFilesystem: false
+#     capabilities:
+#       drop:
+#         - ALL
+#     seccompProfile:
+#       type: RuntimeDefault
+containerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -168,24 +168,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
-# Pod-level security context (applied to all pods)
-# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
-# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+# Pod-level security context (applied to the pod spec)
+# Default only sets seccompProfile. To run as non-root, add:
+#   runAsNonRoot: true
+#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
+#   runAsGroup: 1000
+#   fsGroup: 1000
 podSecurityContext:
-  runAsNonRoot: false
-  runAsUser: 0
-  fsGroup: 0
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container-level security context
+# Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: false
   capabilities:
     drop:
       - ALL
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-frontend/CHANGELOG.md
+++ b/charts/hatchet-frontend/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `podSecurityContext` and `containerSecurityContext` values for Kubernetes Pod Security Standards compliance.
+
 ## [0.10.4] - 2026-03-11
 
 - Updates the default Hatchet image to [`v0.79.12`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.79.12).

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
+          capabilities:
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -98,11 +107,12 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-{{- if .Values.securityContext.enabled }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- end }}
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       volumes:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -49,15 +49,10 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -111,13 +106,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else }}
+{{- else if .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -107,12 +107,18 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- else }}
       securityContext:
         runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
         runAsUser: {{ .Values.podSecurityContext.runAsUser }}
         fsGroup: {{ .Values.podSecurityContext.fsGroup }}
         seccompProfile:
           type: {{ .Values.podSecurityContext.seccompProfileType }}
+{{- end }}
       volumes:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -106,9 +106,11 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else if .Values.podSecurityContext }}
+{{- else }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -110,6 +110,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
+# Pod-level security context (applied to all pods)
+# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
+# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 0
+  seccompProfileType: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfileType: RuntimeDefault
+
 extraConfigMapMounts: []
 
 initContainers: []

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -111,24 +111,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
-# Pod-level security context (applied to all pods)
-# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
-# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+# Pod-level security context (applied to the pod spec)
+# Default only sets seccompProfile. To run as non-root, add:
+#   runAsNonRoot: true
+#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
+#   runAsGroup: 1000
+#   fsGroup: 1000
 podSecurityContext:
-  runAsNonRoot: false
-  runAsUser: 0
-  fsGroup: 0
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container-level security context
+# Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: false
   capabilities:
     drop:
       - ALL
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -112,24 +112,27 @@ securityContext:
   fsGroup: 2000
 
 # Pod-level security context (applied to the pod spec)
-# Default only sets seccompProfile. To run as non-root, add:
-#   runAsNonRoot: true
-#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
-#   runAsGroup: 1000
-#   fsGroup: 1000
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   podSecurityContext:
+#     runAsNonRoot: true
+#     runAsUser: 1000
+#     runAsGroup: 1000
+#     fsGroup: 1000
+#     seccompProfile:
+#       type: RuntimeDefault
+podSecurityContext: {}
 
 # Container-level security context (applied to each container)
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
-  capabilities:
-    drop:
-      - ALL
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     readOnlyRootFilesystem: false
+#     capabilities:
+#       drop:
+#         - ALL
+#     seccompProfile:
+#       type: RuntimeDefault
+containerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -103,7 +103,8 @@ revisionHistoryLimit: 3
 # podDisruptionBudget:
 #   maxUnavailable: 1
 
-# default security context
+# Legacy security context (deprecated — use podSecurityContext instead)
+# Kept for backward compatibility with existing values overrides
 securityContext:
   enabled: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
# Description

Adds configurable pod-level and container-level securityContext to all Hatchet deployments and jobs, enabling Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) restricted profile compliance. Removes hardcoded `SYS_PTRACE` capability from setup job containers.

**All defaults are backward-compatible** — existing deployments are unaffected. Security hardening is opt-in via values.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

### Added
- `podSecurityContext` and `containerSecurityContext` values for hatchet-api and hatchet-frontend charts
- Applied to deployments (api, engine, frontend) and jobs (setup, migration, seed, worker-token)
- `shareProcessNamespace` as a configurable value (default: `true` for backward compatibility)
- Templates use `toYaml` pattern (matching cert-manager/Grafana convention) so users can pass any securityContext field
- Changelog entries for hatchet-api and hatchet-frontend

### Removed
- Hardcoded `SYS_PTRACE` capability from all 4 setup job containers (not used by the codebase — no references in Go code or docker-compose)

### Backward compatibility

- `podSecurityContext` and `containerSecurityContext` default to `{}` (empty) — no security context is applied unless the user opts in
- `shareProcessNamespace` defaults to `true` (matching existing behavior)
- Old `securityContext.enabled` / `securityContext.runAsUser` / `securityContext.fsGroup` values still work
- The only behavioral change is the removal of `SYS_PTRACE`, which was blocking pod creation on clusters with PSA `baseline` enforce

### Opting into PSA restricted

Requires [hatchet-dev/hatchet#3356](https://github.com/hatchet-dev/hatchet/pull/3356) which creates a non-root user (UID 1000) in the Docker images. Once both are merged:

```yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
  seccompProfile:
    type: RuntimeDefault

containerSecurityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: false
  capabilities:
    drop:
      - ALL
  seccompProfile:
    type: RuntimeDefault

shareProcessNamespace: false
```

## Testing

- `helm lint` passes on all 4 charts
- `helm template` renders correctly with default values (backward compatible) and restricted values
- Verified rendered output matches main exactly with default values (minus SYS_PTRACE removal)
- Checkov security scan passes on PSA-critical checks