### PR TITLE
feat: update image tags & frontend health probe support

### DIFF
--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
-version: 0.10.4
+version: 0.10.5
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -1,11 +1,11 @@
 # sharedConfig (typically passed from parent chart)
 sharedConfig:
   image:
-    tag: "v0.79.12"
+    tag: "v0.83.23"
 
 image:
   repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
-  tag: "v0.79.12"
+  tag: "v0.83.23"
   pullPolicy: "IfNotPresent"
 
 postgresImage:
@@ -17,21 +17,21 @@ setupJob:
   enabled: true
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-admin"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
 
 migrationJob:
   enabled: true
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
 
 seedJob:
   enabled: true
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-admin"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
 
 quickstartJob:

--- a/charts/hatchet-frontend/Chart.yaml
+++ b/charts/hatchet-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-frontend
 description: A Helm chart for deploying a frontend static file server on Kubernetes.
 type: application
-version: 0.10.4
+version: 0.10.5
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -69,18 +69,12 @@ spec:
           mountPath: {{ .mountPath }}
           subPath: {{ .subPath }}
 {{- end }}
-        livenessProbe:
-          httpGet:
-            path: /
-            port: {{ .Values.service.internalPort }}
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /
-            port: {{ .Values.service.internalPort }}
-          initialDelaySeconds: 5
-          periodSeconds: 10
+{{- if .Values.health.enabled }}
+{{- $probes := deepCopy .Values.health.spec }}
+{{- $_ := set $probes.livenessProbe.httpGet "port" (coalesce $probes.livenessProbe.httpGet.port .Values.service.internalPort | int) }}
+{{- $_ := set $probes.readinessProbe.httpGet "port" (coalesce $probes.readinessProbe.httpGet.port .Values.service.internalPort | int) }}
+{{ toYaml $probes | indent 8 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -1,11 +1,11 @@
 # sharedConfig (typically passed from parent chart)
 sharedConfig:
   image:
-    tag: "v0.79.12"
+    tag: "v0.83.23"
 
 image:
   repository: "ghcr.io/hatchet-dev/hatchet/hatchet-frontend"
-  tag: "v0.79.12"
+  tag: "v0.83.23"
   pullPolicy: "IfNotPresent"
 
 commandline:
@@ -40,6 +40,23 @@ ingress:
   #     - example.mydomain.com
   # servicePort: service-port
   pathType: ImplementationSpecific
+
+health:
+  enabled: true
+  spec:
+    livenessProbe:
+      httpGet:
+        # Override if env.BASE_PATH set
+        path: /
+        # port: defaults to service.internalPort
+      periodSeconds: 5
+      initialDelaySeconds: 60
+    readinessProbe:
+      httpGet:
+        path: / # override if env.BASE_PATH set
+        # port: defaults to service.internalPort
+      periodSeconds: 5
+      initialDelaySeconds: 20
 
 persistence:
   size: 5Gi

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.10.4
+  version: 0.10.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:cee8a424ce2c7b1b27b6db58575047eabd4527e7846419308091332fe4cba763
-generated: "2026-03-11T13:46:44.006507+01:00"
+digest: sha256:a4630598ad145908bf2f19c3eb3607ebfa6c70e6650d33cac9526cab87e1b026
+generated: "2026-04-17T18:24:07.582437+02:00"

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
-version: 0.10.4
+version: 0.10.5
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run
@@ -10,27 +10,27 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -6,7 +6,7 @@ sharedConfig:
   # if set, this image tag will be used for all Hatchet components (api, grpc, controllers, scheduler, frontend)
   # individual component image.tag values will be used as fallbacks if this is not set
   image:
-    tag: "v0.79.12"
+    tag: "v0.83.23"
 
   # these are the most commonly configured values
   serverUrl: "http://localhost:8080"
@@ -27,12 +27,12 @@ api:
   replicaCount: 2
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   migrationJob:
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
-      tag: "v0.79.12"
+      tag: "v0.83.23"
       pullPolicy: "IfNotPresent"
   serviceAccount:
     create: true
@@ -65,7 +65,7 @@ grpc:
   replicaCount: 1
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-engine"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   setupJob:
     enabled: false
@@ -108,7 +108,7 @@ controllers:
   replicaCount: 1
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-engine"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   setupJob:
     enabled: false
@@ -151,7 +151,7 @@ scheduler:
   replicaCount: 1
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-engine"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   setupJob:
     enabled: false
@@ -191,7 +191,7 @@ frontend:
   enabled: true
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-frontend"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   service:
     externalPort: 8080

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.10.4
+  version: 0.10.5
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.10.4
+  version: 0.10.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:b5f8ac7f3a20d722e1f9b910708948f2efd867699a6ff7efda18b8edfc4ef6f6
-generated: "2026-03-11T13:46:31.946179+01:00"
+digest: sha256:a9d483aa02e4861d3b74d92d887fe93ad4cd0bb6298a06c5f3b465350a6e665f
+generated: "2026-04-17T18:23:47.175056+02:00"

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes together with a PostgreSQL database and RabbitMQ.
 type: application
-version: 0.10.4
+version: 0.10.5
 maintainers:
   - name: Hatchet Engineering
     email: alexander@hatchet.run
@@ -10,17 +10,17 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.10.4"
+    version: "0.10.5"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -6,7 +6,7 @@ sharedConfig:
   # if set, this image tag will be used for all Hatchet components (api, engine, frontend)
   # individual component image.tag values will be used as fallbacks if this is not set
   image:
-    tag: "v0.79.12"
+    tag: "v0.83.23"
 
   # these are the most commonly configured values
   serverUrl: "http://localhost:8080"
@@ -27,12 +27,12 @@ api:
   replicaCount: 2
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   migrationJob:
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
-      tag: "v0.79.12"
+      tag: "v0.83.23"
       pullPolicy: "IfNotPresent"
   serviceAccount:
     create: true
@@ -64,7 +64,7 @@ engine:
   replicaCount: 1
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-engine"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   setupJob:
     enabled: false
@@ -104,7 +104,7 @@ frontend:
   enabled: true
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-frontend"
-    tag: "v0.79.12"
+    tag: "v0.83.23"
     pullPolicy: "IfNotPresent"
   service:
     externalPort: 8080


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Makes frontend deployment's health probe's configurable and updates the image tags across the board to ref `v0.83.23`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Allows `frontend` to specify `liveness` and `readiness` probes, while ensuring the port defaults to `service.internalPort`
- Updates latest image(s) to `v0.83.23`

## TODO
- [ ] Blocked by https://github.com/hatchet-dev/hatchet/pull/3370 -- which should necessitate another version update of images to include latest frontend changes.