### PR TITLE
Add pre-upgrade migration hook

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,6 +99,22 @@ jobs:
             echo "✓ Template rendering successful for $chart_name"
           done
 
+      - name: Assert pre-upgrade migration hook renders
+        run: |
+          helm template test-release charts/hatchet-api --is-upgrade \
+            | grep -q '"helm.sh/hook": pre-upgrade' \
+              || { echo "missing pre-upgrade hook in hatchet-api"; exit 1; }
+
+          helm template test-release charts/hatchet-ha --is-upgrade \
+            | grep -c '"helm.sh/hook": pre-upgrade' \
+            | grep -qx 1 \
+              || { echo "expected exactly one pre-upgrade hook in hatchet-ha"; exit 1; }
+
+          helm template test-release charts/hatchet-stack --is-upgrade \
+            | grep -c '"helm.sh/hook": pre-upgrade' \
+            | grep -qx 1 \
+              || { echo "expected exactly one pre-upgrade hook in hatchet-stack"; exit 1; }
+
   loadtest-stack:
     runs-on: ubuntu-latest
     steps:

--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Run database migrations as a Helm pre-upgrade hook so failed migrations block new application pods from rolling out.
+- Add configurable `migrationJob.activeDeadlineSeconds` and `migrationJob.backoffLimit` values.
+- Retain failed migration hook Jobs by default for debugging.
+
 ## [0.10.5] - 2026-05-01
 
 - Updates the default Hatchet image to [`v0.84.0`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.84.0).

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -24,7 +24,6 @@ spec:
 {{- include "hatchet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -51,10 +50,6 @@ spec:
       - name: migration-job
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
-        securityContext:
-          capabilities:
-            add:
-              - SYS_PTRACE
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -1,3 +1,71 @@
+{{- $runInstallMigrations := and .Values.migrationJob.enabled .Release.IsInstall -}}
+{{- if and .Values.migrationJob.enabled .Release.IsUpgrade }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "hatchet.fullname" . }}-migration
+  labels:
+{{- include "hatchet.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    {{- if .Values.retainFailedHooks }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- else }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
+  template:
+    metadata:
+      name: {{ template "hatchet.fullname" . }}-migration
+      labels:
+{{- include "hatchet.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      shareProcessNamespace: true
+      serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      initContainers:
+      - name: check-db-connection
+        image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
+        imagePullPolicy: {{ .Values.postgresImage.pullPolicy }}
+        command: ['/bin/sh','-lc']
+        args:
+          - |
+            until pg_isready -q -t 5 -d "$DATABASE_URL"; do
+              echo "waiting for database"; sleep 2
+            done
+            psql "$DATABASE_URL" -c "SELECT 1"
+        env:
+      {{- range $key, $value := .Values.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+      {{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+      containers:
+      - name: migration-job
+        image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
+        imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
+        securityContext:
+          capabilities:
+            add:
+              - SYS_PTRACE
+        env:
+        {{- range $key, $value := .Values.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+        {{- end }}
+        {{- if .Values.envFrom }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+        {{- end }}
+---
+{{- end }}
 {{- if .Values.setupJob.enabled }}
 # create a role and rolebinding to write to the configmap
 apiVersion: rbac.authorization.k8s.io/v1
@@ -48,7 +116,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       initContainers:
-      {{- if .Values.migrationJob.enabled }}
+      {{- if $runInstallMigrations }}
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
         imagePullPolicy: {{ .Values.postgresImage.pullPolicy }}
@@ -107,7 +175,7 @@ spec:
 {{ toYaml .Values.envFrom | indent 10 }}
         {{- end }}
       {{- end }}
-      {{- if and (not .Values.migrationJob.enabled) (not .Values.seedJob.enabled) }}
+      {{- if and (not $runInstallMigrations) (not .Values.seedJob.enabled) }}
       []
       {{- end }}
       containers:

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -22,7 +22,9 @@ setupJob:
 
 migrationJob:
   enabled: true
+  # Number of retries before the migration Job is marked failed.
   backoffLimit: 1
+  # Hard timeout (seconds) for the migration Job; raise for long-running schema changes.
   activeDeadlineSeconds: 900
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
@@ -56,6 +58,7 @@ cloudSQLSidecar:
       cpu: 500m
       memory: 512Mi
 
+# Retain failed Helm hook Jobs (currently the pre-upgrade migration hook) so logs survive for debugging.
 retainFailedHooks: true
 
 env: {}

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -22,6 +22,8 @@ setupJob:
 
 migrationJob:
   enabled: true
+  backoffLimit: 1
+  activeDeadlineSeconds: 900
   image:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
     tag: "v0.84.0"
@@ -54,7 +56,7 @@ cloudSQLSidecar:
       cpu: 500m
       memory: 512Mi
 
-retainFailedHooks: false
+retainFailedHooks: true
 
 env: {}
 

--- a/charts/hatchet-ha/CHANGELOG.md
+++ b/charts/hatchet-ha/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Run API database migrations as a Helm pre-upgrade hook so failed migrations block new application pods from rolling out.
+
 ## [0.10.5] - 2026-05-01
 
 - Updates the default Hatchet image to [`v0.84.0`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.84.0).

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -29,10 +29,13 @@ api:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
+  # Retain failed Helm hook Jobs (currently the pre-upgrade migration hook) so logs survive for debugging.
   retainFailedHooks: true
   migrationJob:
     enabled: true
+    # Number of retries before the migration Job is marked failed.
     backoffLimit: 1
+    # Hard timeout (seconds) for the migration Job; raise for long-running schema changes.
     activeDeadlineSeconds: 900
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -29,7 +29,11 @@ api:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
+  retainFailedHooks: true
   migrationJob:
+    enabled: true
+    backoffLimit: 1
+    activeDeadlineSeconds: 900
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
       tag: "v0.84.0"
@@ -68,6 +72,8 @@ grpc:
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
   setupJob:
+    enabled: false
+  migrationJob:
     enabled: false
   service:
     externalPort: 7070
@@ -112,6 +118,8 @@ controllers:
     pullPolicy: "IfNotPresent"
   setupJob:
     enabled: false
+  migrationJob:
+    enabled: false
   service:
     externalPort: 7070
     internalPort: 7070
@@ -154,6 +162,8 @@ scheduler:
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
   setupJob:
+    enabled: false
+  migrationJob:
     enabled: false
   service:
     externalPort: 7070

--- a/charts/hatchet-stack/CHANGELOG.md
+++ b/charts/hatchet-stack/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Run API database migrations as a Helm pre-upgrade hook so failed migrations block new application pods from rolling out.
+
 ## [0.10.5] - 2026-05-01
 
 - Updates the default Hatchet image to [`v0.84.0`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.84.0).

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -29,10 +29,13 @@ api:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
+  # Retain failed Helm hook Jobs (currently the pre-upgrade migration hook) so logs survive for debugging.
   retainFailedHooks: true
   migrationJob:
     enabled: true
+    # Number of retries before the migration Job is marked failed.
     backoffLimit: 1
+    # Hard timeout (seconds) for the migration Job; raise for long-running schema changes.
     activeDeadlineSeconds: 900
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -29,7 +29,11 @@ api:
     repository: "ghcr.io/hatchet-dev/hatchet/hatchet-api"
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
+  retainFailedHooks: true
   migrationJob:
+    enabled: true
+    backoffLimit: 1
+    activeDeadlineSeconds: 900
     image:
       repository: "ghcr.io/hatchet-dev/hatchet/hatchet-migrate"
       tag: "v0.84.0"
@@ -67,6 +71,8 @@ engine:
     tag: "v0.84.0"
     pullPolicy: "IfNotPresent"
   setupJob:
+    enabled: false
+  migrationJob:
     enabled: false
   service:
     externalPort: 7070


### PR DESCRIPTION
- Run API database migrations as a Helm `pre-upgrade` hook so failed migrations stop upgrade rollout before new application pods are applied.
- Add configurable migration job `backoffLimit` and `activeDeadlineSeconds` values.
- Retain failed migration hook jobs by default for debugging.
- Fix setup Job template rendering invalid YAML on upgrade when `seedJob.enabled=false` (empty `initContainers:` bug).
- Extend the `migration-e2e` test (and README) to assert the API Deployment becomes Ready end-to-end against a fresh Postgres, not just that the migration Job completes.

Refs #50

<details>
<summary>Manual cross-version upgrade test (v0.79.12 → v0.84.0)</summary>

Installs the API pinned to `v0.79.12`, then `helm upgrade`s with no image override so the chart default (`v0.84.0`) takes over. The pre-upgrade hook should run with the **new** migrate image and apply exactly the migrations that exist in v0.84.0 but not in v0.79.12. Goose's `goose_db_version` is the source of truth for applied migrations.

```bash
# 0. Clean slate
helm uninstall hatchet-api-test --ignore-not-found
kubectl delete secret hatchet-config --ignore-not-found
helm uninstall pg --ignore-not-found
kubectl delete pvc -l app.kubernetes.io/instance=pg --ignore-not-found

# 1. Fresh Postgres pinned to UTC (Hatchet refuses non-UTC DBs)
helm repo add bitnami https://charts.bitnami.com/bitnami && helm repo update
helm install pg bitnami/postgresql \
  --set image.repository=bitnamilegacy/postgresql \
  --set global.security.allowInsecureImages=true \
  --set auth.username=hatchet --set auth.password=hatchet --set auth.database=hatchet \
  --set tls.enabled=false \
  --set primary.extendedConfiguration="timezone = 'UTC'" \
  --wait --timeout=5m

# 2. hatchet-config Secret (server-level config; quickstartJob will patch in
#    cookie/encryption keys; SERVER_MSGQUEUE_KIND=postgres skips RabbitMQ)
kubectl create secret generic hatchet-config \
  --from-literal=DATABASE_URL='postgres://hatchet:hatchet@pg-postgresql:5432/hatchet?sslmode=disable' \
  --from-literal=SERVER_URL='http://localhost:8080' \
  --from-literal=SERVER_AUTH_COOKIE_DOMAIN='localhost' \
  --from-literal=SERVER_AUTH_COOKIE_INSECURE='t' \
  --from-literal=SERVER_AUTH_SET_EMAIL_VERIFIED='t' \
  --from-literal=SERVER_AUTH_BASIC_AUTH_ENABLED='t' \
  --from-literal=SERVER_GRPC_BROADCAST_ADDRESS='localhost:7070' \
  --from-literal=SERVER_GRPC_INSECURE='t' \
  --from-literal=SERVER_MSGQUEUE_KIND='postgres' \
  --from-literal=ADMIN_EMAIL='admin@example.com' \
  --from-literal=ADMIN_PASSWORD='Admin123!!'

API_ARGS=(
  --set-json 'envFrom=[{"secretRef":{"name":"hatchet-config"}}]'
  --set seedJob.enabled=false
  --set workerTokenJob.enabled=false
  --set ingress.enabled=false
)

# 3. Install OLD (pin everything to v0.79.12 via sharedConfig.image.tag)
helm install hatchet-api-test charts/hatchet-api "${API_ARGS[@]}" \
  --set sharedConfig.image.tag=v0.79.12 \
  --wait --timeout=10m
kubectl rollout status deploy/hatchet-api-test --timeout=5m

# 4. Snapshot BEFORE
echo "=== BEFORE ==="
kubectl exec pg-postgresql-0 -- env PGPASSWORD=hatchet psql -U hatchet -d hatchet -tAc \
  "SELECT count(*) AS migrations, max(version_id) AS max_version FROM goose_db_version WHERE is_applied;"
kubectl get pods -l app.kubernetes.io/instance=hatchet-api-test \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}{end}'

# 5. UPGRADE to NEW (drop the override → chart default v0.84.0)
helm upgrade hatchet-api-test charts/hatchet-api "${API_ARGS[@]}" \
  --wait --timeout=10m
kubectl rollout status deploy/hatchet-api-test --timeout=5m

# 6. Snapshot AFTER
echo "=== AFTER ==="
kubectl exec pg-postgresql-0 -- env PGPASSWORD=hatchet psql -U hatchet -d hatchet -tAc \
  "SELECT count(*) AS migrations, max(version_id) AS max_version FROM goose_db_version WHERE is_applied;"
kubectl get pods -l app.kubernetes.io/instance=hatchet-api-test \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}{end}'

# 7. Migrations applied during the upgrade window
kubectl exec pg-postgresql-0 -- env PGPASSWORD=hatchet psql -U hatchet -d hatchet -c \
  "SELECT version_id, tstamp FROM goose_db_version
     WHERE is_applied AND tstamp > now() - interval '15 minutes'
     ORDER BY tstamp DESC LIMIT 30;"

# 8. Helm release history
helm history hatchet-api-test
```

Observed (abbreviated):

```
=== BEFORE ===
169|20260223180620
hatchet-api-test-...    ghcr.io/hatchet-dev/hatchet/hatchet-api:v0.79.12

=== AFTER ===
189|20260427190534
hatchet-api-test-...    ghcr.io/hatchet-dev/hatchet/hatchet-api:v0.84.0

# Step 7 shows two clean clusters of tstamps:
#   14:27:06 -> 10 rows, version_id <= 20260223180620  (v0.79.12 install-time)
#   14:29:17 -> 20 rows, version_id >= 20260302193424  (v0.84.0 pre-upgrade hook)

REVISION  STATUS       CHART                 DESCRIPTION
1         superseded   hatchet-api-0.10.5    Install complete
2         deployed     hatchet-api-0.10.5    Upgrade complete
```

Result: +20 migrations applied during `helm upgrade`, max `version_id` advanced from `20260223180620` to `20260427190534`, API Deployment rolled over from `v0.79.12` to `v0.84.0` cleanly. If the pre-upgrade hook hadn't run, or had run with the old image, neither of these would be true.

</details>