### PR TITLE
feat(hatchet-stack): allow fronting Caddy behind a Service/ingress

### DIFF
--- a/charts/hatchet-stack/templates/caddy.yaml
+++ b/charts/hatchet-stack/templates/caddy.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- end }}
 data:
   Caddyfile: |
-    http://localhost:8080 {
+    {{ .Values.caddy.address | default "http://localhost:8080" }} {
         handle /api/* {
             reverse_proxy {{ .Release.Name }}-api:8080
         }
@@ -74,5 +74,5 @@ spec:
     - protocol: TCP
       port: 8080
       targetPort: 8080
-  type: LoadBalancer
+  type: {{ .Values.caddy.service.type | default "LoadBalancer" }}
 {{- end -}}

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -162,3 +162,16 @@ caddy:
     repository: "caddy"
     tag: "2.7.6-alpine"
     pullPolicy: "IfNotPresent"
+  # Caddy site address (the top line of the generated Caddyfile block). The
+  # default http://localhost:8080 matches the documented `kubectl port-forward`
+  # workflow, where Caddy only needs to serve requests with Host: localhost. Set
+  # to ":8080" to serve any Host instead, e.g. when fronting Caddy with an
+  # ingress, service mesh, or VPN overlay (Tailscale) where the request Host is
+  # not localhost.
+  address: "http://localhost:8080"
+  service:
+    # Service type for the Caddy reverse proxy. Defaults to LoadBalancer
+    # (unchanged behaviour). Set to ClusterIP to front Caddy with your own
+    # ingress, service mesh, or VPN overlay (e.g. Tailscale) instead of
+    # provisioning a cloud load balancer.
+    type: LoadBalancer


### PR DESCRIPTION
# Description

The Caddy reverse proxy is set up for the documented `kubectl port-forward` workflow: the site is bound to http://localhost:8080 (only serves Host: localhost) and the Service is type LoadBalancer. To let Caddy also act as a single-origin entrypoint behind an ingress, service mesh, or VPN overlay (e.g. Tailscale), where the request Host is not localhost and a cloud LB is not wanted, add two additive, default-preserving values:

- `caddy.address` (default "http://localhost:8080", unchanged) - the Caddy site address; set ":8080" to serve any Host.
- `caddy.service.type` (default "LoadBalancer", unchanged) - set "ClusterIP" to front Caddy yourself.

No behaviour change by default; the port-forward workflow is unaffected. Validated with `helm template` (defaults + overrides) and live in a cluster: with both set, /api -> api and / -> frontend route correctly through a ClusterIP Service on a non-localhost Host.


## Type of change

- [ X ] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- `caddy.address` (default "http://localhost:8080", unchanged) - the Caddy site address; set ":8080" to serve any Host.
- `caddy.service.type` (default "LoadBalancer", unchanged) - set "ClusterIP" to front Caddy yourself.
