### PR TITLE
fix: propagate imagePullSecrets to job pod specs in setup-job.yaml

### DIFF
--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -25,6 +25,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
@@ -107,6 +111,10 @@ spec:
       restartPolicy: Never
       shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
@@ -218,6 +226,10 @@ spec:
       restartPolicy: Never
       shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}


### PR DESCRIPTION
## Summary

The `deployment.yaml` template correctly renders `imagePullSecrets` from `.Values.image.pullSecrets`, but `setup-job.yaml` does not. This causes all job pods (migration, setup, seed, worker-token) to fail with `403 Forbidden` when pulling images from private or cross-account container registries, while deployment pods (api, engine, controllers, scheduler, frontend) succeed using the same values.

**Root cause:** `setup-job.yaml` never reads `.Values.image.pullSecrets` — the value is accepted in helm values but silently ignored for job pod specs.

**Fix:** Add the same `imagePullSecrets` block to all three job pod specs in `setup-job.yaml`, matching the existing pattern in `deployment.yaml:99-102`:

```yaml
{{- if .Values.image.pullSecrets }}
imagePullSecrets:
{{ toYaml .Values.image.pullSecrets | indent 8 }}
{{- end }}
```

## Affected job pods

- Migration hook job (pre-upgrade)
- Main setup job (migration init + seed init + quickstart container)
- Worker token job

## How to reproduce

1. Deploy `hatchet-ha` with images in a private/cross-account ECR registry
2. Set `api.image.pullSecrets` in values
3. Deployments pull successfully; migration job fails with `403 Forbidden`
4. `hatchet-config` secret is never created (migration must complete first)
5. All other pods cascade-fail with `CreateContainerConfigError`

## Test plan

- [ ] `helm template` with `image.pullSecrets` set — verify `imagePullSecrets` appears in all job pod specs
- [ ] Deploy to a cluster with cross-account ECR — migration job should pull successfully