### PR TITLE
Make Caddy listen address configurable and default to :8080

### DIFF
--- a/charts/hatchet-stack/templates/caddy.yaml
+++ b/charts/hatchet-stack/templates/caddy.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- end }}
 data:
   Caddyfile: |
-    http://localhost:8080 {
+    {{ .Values.caddy.listenAddress | default ":8080" }} {
         handle /api/* {
             reverse_proxy {{ .Release.Name }}-api:8080
         }

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -158,6 +158,7 @@ rabbitmq:
 
 caddy:
   enabled: false
+  listenAddress: ":8080"  # use ":8080" to accept any Host, or "http://localhost:8080" for localhost only
   image:
     repository: "caddy"
     tag: "2.7.6-alpine"


### PR DESCRIPTION
# Description

The Caddyfile is hardcoded to listen on http://localhost:8080, which means Caddy only responds to requests where the Host header is exactly localhost:8080.
This causes issues when exposing the dashboard through an ingress controller. [check here](https://github.com/hatchet-dev/hatchet/issues/4224)

Fixes # (issue)
caddy.yaml : Replace hardcoded http://localhost:8080 with {{ .Values.caddy.listenAddress | default ":8080" }}
values.yaml: Add caddy.listenAddress parameter (defaults to :8080)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

caddy.yaml : Replace hardcoded http://localhost:8080 with {{ .Values.caddy.listenAddress | default ":8080" }}
values.yaml: Add caddy.listenAddress parameter (defaults to :8080)..
