### PR TITLE
fix: `hatchet-ha` should pin `SERVER_SERVICES` to each component

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,9 @@ jobs:
         run: |
           helm unittest charts/hatchet-api
 
+      - name: Assert hatchet-ha pins SERVER_SERVICES per role
+        run: ./hack/test-ha-server-services.sh
+
       - name: Install and test hatchet-api chart
         run: |
           helm install hatchet-api-test charts/hatchet-api \

--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.12.2
+version: 0.12.3
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-frontend/Chart.yaml
+++ b/charts/hatchet-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-frontend
 description: A Helm chart for deploying a frontend static file server on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.12.2
+version: 0.12.3
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.12.2
+  version: 0.12.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:470c4c0f5c3ec2bdf2c836151bc2a917245ec7a168c6bdee1da7f3923bb914de
-generated: "2026-07-06T22:10:18.702064+02:00"
+digest: sha256:802093b3359d1cd3e76164a286daea217140fdc33754c4331032d8111ea99bf6
+generated: "2026-07-07T20:00:51.612643+02:00"

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.12.2
+version: 0.12.3
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -28,27 +28,27 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -89,6 +89,8 @@ grpc:
   serviceAccount:
     create: true
     name: hatchet-grpc
+  env:
+    SERVER_SERVICES: "grpc-api"
   envFrom:
     - secretRef:
         name: hatchet-shared-config
@@ -134,6 +136,8 @@ controllers:
   serviceAccount:
     create: true
     name: controllers
+  env:
+    SERVER_SERVICES: "controllers"
   envFrom:
     - secretRef:
         name: hatchet-shared-config
@@ -179,6 +183,8 @@ scheduler:
   serviceAccount:
     create: true
     name: scheduler
+  env:
+    SERVER_SERVICES: "scheduler"
   envFrom:
     - secretRef:
         name: hatchet-shared-config

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.12.2
+  version: 0.12.3
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.12.2
+  version: 0.12.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:395917a5b3b04a7a3d2b0ad9454a38d7aa6362bbb8debc4cb501cbbff198bfb6
-generated: "2026-07-06T22:10:09.576842+02:00"
+digest: sha256:ba8f89f32481d66f386deae365705da96d7933e6448db8fa80bcc649a18d8065
+generated: "2026-07-07T20:00:42.232974+02:00"

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.12.2
+version: 0.12.3
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -27,17 +27,17 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.12.2"
+    version: "0.12.3"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/hack/test-ha-server-services.sh
+++ b/hack/test-ha-server-services.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Guards against a regression where SERVER_SERVICES is dropped from the hatchet-ha
+# chart. The engine splits into three roles (grpc-api, controllers, scheduler) and
+# each deployment must pin its role via SERVER_SERVICES, otherwise every replica
+# boots every service. We render the chart and assert each deployment's container
+# carries the expected value. Run from the repo root: ./hack/test-ha-server-services.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "Building hatchet-ha chart dependencies..."
+helm dependency build charts/hatchet-ha >/dev/null
+
+rendered="$(helm template t charts/hatchet-ha 2>/dev/null)"
+if [ -z "$rendered" ]; then
+  echo "  ✗ FAIL: helm template produced no output"
+  exit 1
+fi
+
+# Extract (container-name, SERVER_SERVICES value) pairs from the rendered manifests.
+# Container entries live at a 6-space indent under containers:; SERVER_SERVICES is an
+# env entry two levels deeper, so its value belongs to the most recent container.
+pairs="$(printf '%s\n' "$rendered" | awk '
+  /^      - name: / { container = $3; gsub(/"/, "", container) }
+  /^        - name: "SERVER_SERVICES"/ { want = 1; next }
+  want && /^          value:/ { val = $2; gsub(/"/, "", val); print container, val; want = 0 }
+')"
+
+# expected container-name -> SERVER_SERVICES value (kept portable for bash 3.2)
+expected_for() {
+  case "$1" in
+    grpc)        echo "grpc-api" ;;
+    controllers) echo "controllers" ;;
+    scheduler)   echo "scheduler" ;;
+  esac
+}
+
+fails=0
+for svc in grpc controllers scheduler; do
+  want="$(expected_for "$svc")"
+  got="$(printf '%s\n' "$pairs" | awk -v s="$svc" '$1 == s { print $2 }')"
+  if [ -z "$got" ]; then
+    echo "  ✗ FAIL: [$svc] no SERVER_SERVICES env rendered"
+    fails=$((fails + 1))
+  elif [ "$got" != "$want" ]; then
+    echo "  ✗ FAIL: [$svc] SERVER_SERVICES is \"$got\", expected \"$want\""
+    fails=$((fails + 1))
+  else
+    echo "  ✓ [$svc] SERVER_SERVICES=\"$got\""
+  fi
+done
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "$fails SERVER_SERVICES assertion(s) failed."
+  exit 1
+fi
+echo "All SERVER_SERVICES assertions passed."


### PR DESCRIPTION
# Description

Fixes a regression in the `hatchet-ha` chart that removed the `SERVER_SERVICES` env var to pin singular engine component.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Adds the required `SERVER_SERVICES` env var to the `hatchet-ha` chart
- [x] Adds automated CI test to check for regression going forward
