### PR TITLE
feat: add PSA restricted compliance — securityContext, remove SYS_PTRACE

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `podSecurityContext` and `containerSecurityContext` values for Kubernetes Pod Security Standards compliance.
+- `shareProcessNamespace` as a configurable value (default: `true` for backward compatibility).
+
+### Removed
+- Hardcoded `SYS_PTRACE` capability from migration, seed, and setup job containers.
+
+### Changed
+- Init container (`check-db-connection`) security context is now values-driven, matching other containers.
+
 ## [0.11.0] - 2026-05-19
 
 - Run database migrations as a Helm pre-upgrade hook so failed migrations block new application pods from rolling out.

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
+          capabilities:
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
         - name: "{{ $key }}"
@@ -114,6 +123,13 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- else }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -118,9 +118,11 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else if .Values.podSecurityContext }}
+{{- else }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -49,15 +49,10 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
         - name: "{{ $key }}"
@@ -123,13 +118,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else }}
+{{- else if .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -205,6 +205,10 @@ spec:
       - name: empty
         image: "alpine:3.14"
         command: ["sh", "-c", "echo 'No setup job configured'"]
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 ---
 {{- if .Values.workerTokenJob.enabled }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -110,6 +110,7 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       {{- if or $runInstallMigrations .Values.seedJob.enabled }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -131,11 +132,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
       {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
 {{ toYaml .Values.envFrom | indent 10 }}
 
@@ -228,6 +228,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -247,11 +248,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
 {{ toYaml .Values.deploymentEnvFrom | nindent 10 }}
 {{- if .Values.envFrom }}

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -105,12 +105,17 @@ spec:
 {{- include "hatchet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       {{- if or $runInstallMigrations .Values.seedJob.enabled }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       initContainers:
       {{- if $runInstallMigrations }}
       - name: check-db-connection
@@ -128,6 +133,11 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
       {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         envFrom:
 {{ toYaml .Values.envFrom | indent 10 }}
 
@@ -136,9 +146,14 @@ spec:
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -156,9 +171,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "quickstart", "--skip", "certs", "--skip", "keys"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
           - name: SERVER_DEFAULT_ENGINE_VERSION
             value: "V1"
@@ -180,9 +200,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "quickstart", "--namespace", "{{ .Release.Namespace }}", "--overwrite=false"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -216,11 +241,16 @@ spec:
 {{- include "hatchet.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      shareProcessNamespace: true
       serviceAccountName: {{ template "hatchet.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       initContainers:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
@@ -236,6 +266,11 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         envFrom:
 {{ toYaml .Values.deploymentEnvFrom | nindent 10 }}
 {{- if .Values.envFrom }}
@@ -248,9 +283,14 @@ spec:
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "create-worker-token", "--namespace", "{{ .Release.Namespace }}"]
         securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
           capabilities:
-            add:
-              - SYS_PTRACE
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -110,12 +110,10 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       {{- if or $runInstallMigrations .Values.seedJob.enabled }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- if $runInstallMigrations }}
       - name: check-db-connection
@@ -145,15 +143,10 @@ spec:
       - name: migration-job
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -170,15 +163,10 @@ spec:
         imagePullPolicy: {{ .Values.seedJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "quickstart", "--skip", "certs", "--skip", "keys"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: SERVER_DEFAULT_ENGINE_VERSION
             value: "V1"
@@ -199,15 +187,10 @@ spec:
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "quickstart", "--namespace", "{{ .Release.Namespace }}", "--overwrite=false"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -245,12 +228,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
@@ -282,15 +263,10 @@ spec:
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "create-worker-token", "--namespace", "{{ .Release.Namespace }}"]
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -174,28 +174,31 @@ securityContext:
   fsGroup: 2000
 
 # Pod-level security context (applied to the pod spec)
-# Default only sets seccompProfile. To run as non-root, add:
-#   runAsNonRoot: true
-#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
-#   runAsGroup: 1000
-#   fsGroup: 1000
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   podSecurityContext:
+#     runAsNonRoot: true
+#     runAsUser: 1000
+#     runAsGroup: 1000
+#     fsGroup: 1000
+#     seccompProfile:
+#       type: RuntimeDefault
+podSecurityContext: {}
 
+# Share process namespace between containers in job pods.
 # Kept as true for backward compatibility. Set to false for PSA restricted compliance.
 shareProcessNamespace: true
 
 # Container-level security context (applied to each container)
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  # readOnlyRootFilesystem defaults to false because upstream hatchet images write to the filesystem
-  readOnlyRootFilesystem: false
-  capabilities:
-    drop:
-      - ALL
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     readOnlyRootFilesystem: false
+#     capabilities:
+#       drop:
+#         - ALL
+#     seccompProfile:
+#       type: RuntimeDefault
+containerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -173,24 +173,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
-# Pod-level security context (applied to all pods)
-# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
-# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+# Pod-level security context (applied to the pod spec)
+# Default only sets seccompProfile. To run as non-root, add:
+#   runAsNonRoot: true
+#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
+#   runAsGroup: 1000
+#   fsGroup: 1000
 podSecurityContext:
-  runAsNonRoot: false
-  runAsUser: 0
-  fsGroup: 0
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container-level security context
+# Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: false
   capabilities:
     drop:
       - ALL
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -183,7 +183,8 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-shareProcessNamespace: false
+# Kept as true for backward compatibility. Set to false for PSA restricted compliance.
+shareProcessNamespace: true
 
 # Container-level security context (applied to each container)
 containerSecurityContext:

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -165,12 +165,32 @@ revisionHistoryLimit: 3
 # podDisruptionBudget:
 #   maxUnavailable: 1
 
-# default security context
+# Legacy security context (deprecated — use podSecurityContext instead)
+# Kept for backward compatibility with existing values overrides
 securityContext:
   enabled: false
   allowPrivilegeEscalation: false
   runAsUser: 1000
   fsGroup: 2000
+
+# Pod-level security context (applied to all pods)
+# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
+# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 0
+  seccompProfileType: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfileType: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -183,9 +183,12 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+shareProcessNamespace: false
+
 # Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem defaults to false because upstream hatchet images write to the filesystem
   readOnlyRootFilesystem: false
   capabilities:
     drop:

--- a/charts/hatchet-frontend/CHANGELOG.md
+++ b/charts/hatchet-frontend/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `podSecurityContext` and `containerSecurityContext` values for Kubernetes Pod Security Standards compliance.
+
 ## [0.11.0] - 2026-05-19
 
 - Chart version bump only; no template changes in this release.

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
+          capabilities:
+            drop:
+            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
+          seccompProfile:
+            type: {{ .Values.containerSecurityContext.seccompProfileType }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -98,11 +107,12 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-{{- if .Values.securityContext.enabled }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- end }}
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfileType }}
       volumes:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -49,15 +49,10 @@ spec:
         {{- else }}
         args: []
         {{- end }}
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-          capabilities:
-            drop:
-            {{- toYaml .Values.containerSecurityContext.capabilities.drop | nindent 14 }}
-          seccompProfile:
-            type: {{ .Values.containerSecurityContext.seccompProfileType }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -111,13 +106,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else }}
+{{- else if .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        seccompProfile:
-          type: {{ .Values.podSecurityContext.seccompProfileType }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -107,12 +107,18 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- else }}
       securityContext:
         runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
         runAsUser: {{ .Values.podSecurityContext.runAsUser }}
         fsGroup: {{ .Values.podSecurityContext.fsGroup }}
         seccompProfile:
           type: {{ .Values.podSecurityContext.seccompProfileType }}
+{{- end }}
       volumes:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/hatchet-frontend/templates/deployment.yaml
+++ b/charts/hatchet-frontend/templates/deployment.yaml
@@ -106,9 +106,11 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-{{- else if .Values.podSecurityContext }}
+{{- else }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
       volumes:
 {{- if .Values.extraVolumes }}

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -110,6 +110,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
+# Pod-level security context (applied to all pods)
+# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
+# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+podSecurityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 0
+  seccompProfileType: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfileType: RuntimeDefault
+
 extraConfigMapMounts: []
 
 initContainers: []

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -111,24 +111,25 @@ securityContext:
   runAsUser: 1000
   fsGroup: 2000
 
-# Pod-level security context (applied to all pods)
-# To run as non-root, set runAsNonRoot: true and runAsUser: 1000
-# (requires Hatchet images with the hatchet user created, see hatchet-dev/hatchet#3356)
+# Pod-level security context (applied to the pod spec)
+# Default only sets seccompProfile. To run as non-root, add:
+#   runAsNonRoot: true
+#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
+#   runAsGroup: 1000
+#   fsGroup: 1000
 podSecurityContext:
-  runAsNonRoot: false
-  runAsUser: 0
-  fsGroup: 0
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container-level security context
+# Container-level security context (applied to each container)
 containerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: false
   capabilities:
     drop:
       - ALL
-  seccompProfileType: RuntimeDefault
+  seccompProfile:
+    type: RuntimeDefault
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -112,24 +112,27 @@ securityContext:
   fsGroup: 2000
 
 # Pod-level security context (applied to the pod spec)
-# Default only sets seccompProfile. To run as non-root, add:
-#   runAsNonRoot: true
-#   runAsUser: 1000   # must match Dockerfile USER (see hatchet-dev/hatchet#3356)
-#   runAsGroup: 1000
-#   fsGroup: 1000
-podSecurityContext:
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   podSecurityContext:
+#     runAsNonRoot: true
+#     runAsUser: 1000
+#     runAsGroup: 1000
+#     fsGroup: 1000
+#     seccompProfile:
+#       type: RuntimeDefault
+podSecurityContext: {}
 
 # Container-level security context (applied to each container)
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
-  capabilities:
-    drop:
-      - ALL
-  seccompProfile:
-    type: RuntimeDefault
+# Empty by default for backward compatibility. For PSA restricted compliance, set:
+#   containerSecurityContext:
+#     allowPrivilegeEscalation: false
+#     readOnlyRootFilesystem: false
+#     capabilities:
+#       drop:
+#         - ALL
+#     seccompProfile:
+#       type: RuntimeDefault
+containerSecurityContext: {}
 
 extraConfigMapMounts: []
 

--- a/charts/hatchet-frontend/values.yaml
+++ b/charts/hatchet-frontend/values.yaml
@@ -103,7 +103,8 @@ revisionHistoryLimit: 3
 # podDisruptionBudget:
 #   maxUnavailable: 1
 
-# default security context
+# Legacy security context (deprecated — use podSecurityContext instead)
+# Kept for backward compatibility with existing values overrides
 securityContext:
   enabled: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
# Description

Adds configurable pod-level and container-level securityContext to all Hatchet deployments and jobs, enabling Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) restricted profile compliance. Removes hardcoded `SYS_PTRACE` capability from setup job containers.

**All defaults are backward-compatible** — existing deployments are unaffected. Security hardening is opt-in via values.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

### Added
- `podSecurityContext` and `containerSecurityContext` values for hatchet-api and hatchet-frontend charts
- Applied to deployments (api, engine, frontend) and jobs (setup, migration, seed, worker-token)
- `shareProcessNamespace` as a configurable value (default: `true` for backward compatibility)
- Templates use `toYaml` pattern (matching cert-manager/Grafana convention) so users can pass any securityContext field
- Changelog entries for hatchet-api and hatchet-frontend

### Removed
- Hardcoded `SYS_PTRACE` capability from all 4 setup job containers (not used by the codebase — no references in Go code or docker-compose)

### Backward compatibility

- `podSecurityContext` and `containerSecurityContext` default to `{}` (empty) — no security context is applied unless the user opts in
- `shareProcessNamespace` defaults to `true` (matching existing behavior)
- Old `securityContext.enabled` / `securityContext.runAsUser` / `securityContext.fsGroup` values still work
- The only behavioral change is the removal of `SYS_PTRACE`, which was blocking pod creation on clusters with PSA `baseline` enforce

### Opting into PSA restricted

Requires [hatchet-dev/hatchet#3356](https://github.com/hatchet-dev/hatchet/pull/3356) which creates a non-root user (UID 1000) in the Docker images. Once both are merged:

```yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
  seccompProfile:
    type: RuntimeDefault

containerSecurityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: false
  capabilities:
    drop:
      - ALL
  seccompProfile:
    type: RuntimeDefault

shareProcessNamespace: false
```

## Testing

- `helm lint` passes on all 4 charts
- `helm template` renders correctly with default values (backward compatible) and restricted values
- Verified rendered output matches main exactly with default values (minus SYS_PTRACE removal)
- Checkov security scan passes on PSA-critical checks