### PR TITLE
feat: allow args for `cloudSQLSidecar `

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-16
+
+- Make the Cloud SQL Auth Proxy sidecar flags configurable via `cloudSQLSidecar.args` (defaults to `--private-ip`, `--structured-logs`, `--port=5432`); `cloudSQLSidecar.address` is still appended as the final proxy argument.
+- Remove the hardcoded `SERVER_DEFAULT_ENGINE_VERSION=V1` environment variable from the setup Job.
+
+## [0.13.0] - 2026-07-14
+
+- Updates the default Hatchet image to [`v0.94.10`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.94.10).
+
+## [0.12.4] - 2026-07-09
+
+- Render `envFrom` and `deploymentEnvFrom` through `tpl` in the deployment and setup Job templates, so secret/configmap names can reference release values (e.g. `name: '{{ .Release.Name }}-postgres-secret'`).
+
+## [0.12.3] - 2026-07-07
+
+- Chart version bump only; no template changes in this release.
+
 ## [0.12.2] - 2026-07-06
 
 - Add icon for chart
@@ -90,7 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-api-0.12.2...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-api-0.13.1...HEAD
+[0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.13.1
+[0.13.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.13.0
+[0.12.4]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.12.4
+[0.12.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.12.3
 [0.12.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.12.2
 [0.12.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.12.1
 [0.12.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.12.0

--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.0
+version: 0.13.1
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-api/README.md
+++ b/charts/hatchet-api/README.md
@@ -72,7 +72,8 @@ This chart ships a [`values.schema.json`](https://github.com/hatchet-dev/hatchet
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `cloudSQLSidecar.enabled` | bool | `false` | Enable the Google Cloud SQL Auth Proxy sidecar. |
-| `cloudSQLSidecar.address` | string | `""` | Cloud SQL instance connection address. |
+| `cloudSQLSidecar.address` | string | `""` | Cloud SQL instance connection address (appended as the final proxy argument). |
+| `cloudSQLSidecar.args` | list | `["--private-ip", "--structured-logs", "--port=5432"]` | Flags passed to the proxy before the address. Override to add flags such as `--auto-iam-authn`. |
 | `cloudSQLSidecar.resources` | object | see `values.yaml` | Resources for the Cloud SQL sidecar. |
 
 ### Deployment

--- a/charts/hatchet-api/templates/deployment.yaml
+++ b/charts/hatchet-api/templates/deployment.yaml
@@ -84,9 +84,9 @@ spec:
       - name: cloud-sql-proxy
         image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.0
         args:
-        - "--private-ip"
-        - "--structured-logs"
-        - "--port=5432"
+{{- range .Values.cloudSQLSidecar.args }}
+        - "{{ . }}"
+{{- end }}
         - "{{ .Values.cloudSQLSidecar.address }}"
         securityContext:
           runAsNonRoot: true

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -160,8 +160,6 @@ spec:
             add:
               - SYS_PTRACE
         env:
-          - name: SERVER_DEFAULT_ENGINE_VERSION
-            value: "V1"
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"

--- a/charts/hatchet-api/values.schema.json
+++ b/charts/hatchet-api/values.schema.json
@@ -118,6 +118,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "address": { "type": "string" },
+        "args": { "type": "array", "items": { "type": "string" } },
         "resources": { "$ref": "#/$defs/resources" }
       }
     },

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -51,6 +51,10 @@ commandline:
 cloudSQLSidecar:
   enabled: false
   address: ""
+  args:
+    - "--private-ip"
+    - "--structured-logs"
+    - "--port=5432"
   resources:
     limits:
       memory: 512Mi

--- a/charts/hatchet-frontend/CHANGELOG.md
+++ b/charts/hatchet-frontend/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-16
+
+- Chart version bump only; no template changes in this release.
+
+## [0.13.0] - 2026-07-14
+
+- Updates the default Hatchet image to [`v0.94.10`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.94.10).
+
+## [0.12.4] - 2026-07-09
+
+- Chart version bump only; no template changes in this release.
+
+## [0.12.3] - 2026-07-07
+
+- Chart version bump only; no template changes in this release.
+
 ## [0.12.2] - 2026-07-06
 
 - Add icon for chart
@@ -81,7 +97,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-frontend-0.12.2...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-frontend-0.13.1...HEAD
+[0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.13.1
+[0.13.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.13.0
+[0.12.4]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.12.4
+[0.12.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.12.3
 [0.12.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.12.2
 [0.12.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.12.1
 [0.12.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.12.0

--- a/charts/hatchet-frontend/Chart.yaml
+++ b/charts/hatchet-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-frontend
 description: A Helm chart for deploying a frontend static file server on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.0
+version: 0.13.1
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-ha/CHANGELOG.md
+++ b/charts/hatchet-ha/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-16
+
+- Bump the bundled `hatchet-api` and `hatchet-frontend` subcharts to `0.13.1`.
+
+## [0.13.0] - 2026-07-14
+
+- Updates the default Hatchet image to [`v0.94.10`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.94.10).
+
+## [0.12.4] - 2026-07-09
+
+- Add `global.sharedConfigSecretName` to rename the `hatchet-shared-config` Secret (defaults to `hatchet-shared-config`). The value is passed through `tpl`, so a release-scoped name such as `'{{ .Release.Name }}-shared-config'` lets multiple releases run in the same namespace without a name collision.
+- Render each backend component's `envFrom` (and `deploymentEnvFrom`) through `tpl`, so secret/configmap names can reference release values.
+
+## [0.12.3] - 2026-07-07
+
+- Pin `SERVER_SERVICES` per component: `grpc-api` for `grpc`, `controllers` for `controllers`, and `scheduler` for `scheduler`.
+
 ## [0.12.2] - 2026-07-06
 
 - Add icon for chart
@@ -72,7 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2024-11-22
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-ha-0.12.2...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-ha-0.13.1...HEAD
+[0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.13.1
+[0.13.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.13.0
+[0.12.4]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.12.4
+[0.12.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.12.3
 [0.12.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.12.2
 [0.12.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.12.1
 [0.12.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.12.0

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.13.0
+  version: 0.13.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:22383766f4b176c927b847029972ff10901d353ad16a0877c86955e540b202e4
-generated: "2026-07-14T16:54:02.379677996Z"
+digest: sha256:51d73a15f15f77fd91665079a1f451f6e8c4bc910f98d07bc9d80ed5fc0fc832
+generated: "2026-07-16T14:22:10.385782+02:00"

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.0
+version: 0.13.1
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -28,27 +28,27 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-ha/templates/secret.yaml
+++ b/charts/hatchet-ha/templates/secret.yaml
@@ -11,7 +11,6 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  SERVER_DEFAULT_ENGINE_VERSION: "{{ "V1" | b64enc }}"
 {{- if .Values.postgres.enabled }}
   DATABASE_URL: "{{ printf "postgres://%s:%s@%s-postgres:%d/%s?sslmode=%s" .Values.postgres.auth.username .Values.postgres.auth.password .Release.Name (.Values.postgres.primary.service.ports.postgresql | int) .Values.postgres.auth.database (ternary "require" "disable" .Values.postgres.tls.enabled) | b64enc }}"
 {{- end }}

--- a/charts/hatchet-stack/CHANGELOG.md
+++ b/charts/hatchet-stack/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-16
+
+- Remove the hardcoded `SERVER_DEFAULT_ENGINE_VERSION` key from the rendered `hatchet-shared-config` Secret.
+- Bump the bundled `hatchet-api` and `hatchet-frontend` subcharts to `0.13.1`.
+
+## [0.13.0] - 2026-07-14
+
+- Updates the default Hatchet image to [`v0.94.10`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.94.10).
+
+## [0.12.4] - 2026-07-09
+
+- Add `global.sharedConfigSecretName` to rename the `hatchet-shared-config` Secret (defaults to `hatchet-shared-config`). The value is passed through `tpl`, so a release-scoped name such as `'{{ .Release.Name }}-shared-config'` lets multiple releases run in the same namespace without a name collision.
+- Render each backend component's `envFrom` (and `deploymentEnvFrom`) through `tpl`, so secret/configmap names can reference release values.
+
+## [0.12.3] - 2026-07-07
+
+- Chart version bump only; no template changes in this release.
+
 ## [0.12.2] - 2026-07-06
 
 - Add icon for chart
@@ -88,7 +106,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-stack-0.12.2...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-stack-0.13.1...HEAD
+[0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.13.1
+[0.13.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.13.0
+[0.12.4]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.12.4
+[0.12.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.12.3
 [0.12.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.12.2
 [0.12.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.12.1
 [0.12.0]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.12.0

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.0
+  version: 0.13.1
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.13.0
+  version: 0.13.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:66989e46935028f1c0749fd16da36327b9051c98730099f0dc6d7914a33a92a1
-generated: "2026-07-14T16:54:18.869374377Z"
+digest: sha256:69e316020de52706670233191fcf92398a5eb19f2cb76aba9f75b3a9bd7fa294
+generated: "2026-07-16T14:22:01.389265+02:00"

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.0
+version: 0.13.1
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -27,17 +27,17 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.13.0"
+    version: "0.13.1"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-stack/templates/secret.yaml
+++ b/charts/hatchet-stack/templates/secret.yaml
@@ -11,7 +11,6 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  SERVER_DEFAULT_ENGINE_VERSION: "{{ "V1" | b64enc }}"
 {{- if .Values.postgres.enabled }}
   DATABASE_URL: "{{ printf "postgres://%s:%s@%s-postgres:%d/%s?sslmode=%s" .Values.postgres.auth.username .Values.postgres.auth.password .Release.Name (.Values.postgres.primary.service.ports.postgresql | int) .Values.postgres.auth.database (ternary "require" "disable" .Values.postgres.tls.enabled) | b64enc }}"
 {{- end }}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allows passing `args` to the CloudSQL sidecar container. 

Also removes the deprecated engine version env var.

Fixes https://github.com/hatchet-dev/hatchet-charts/issues/46

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (changes which are not directly related to any business logic)
