### PR TITLE
feat: jaegar trace sink for loadtests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Install charts
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.1.0
 
       - name: Set up kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Add Helm repositories
         run: |
@@ -366,7 +366,7 @@ jobs:
           skip_check: CKV_K8S_40,CKV_K8S_43
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+        uses: github/codeql-action/upload-sarif@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
         if: always()
         with:
           sarif_file: reports/results.sarif

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -289,6 +289,18 @@ jobs:
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
 
+      - name: Upload loadtest traces & summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: loadtest-stack-${{ needs.resolve-version.outputs.version }}
+          path: |
+            /tmp/loadtest-traces.json
+            /tmp/loadtest-summary.json
+            /tmp/loadtest-logs.txt
+          if-no-files-found: warn
+          retention-days: 30
+
   loadtest-ha:
     needs: resolve-version
     runs-on: hatchet-arm64-2
@@ -325,6 +337,18 @@ jobs:
           ./hack/kind-ha-loadtest.sh
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
+
+      - name: Upload loadtest traces & summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: loadtest-ha-${{ needs.resolve-version.outputs.version }}
+          path: |
+            /tmp/loadtest-traces.json
+            /tmp/loadtest-summary.json
+            /tmp/loadtest-logs.txt
+          if-no-files-found: warn
+          retention-days: 30
 
   security-scan:
     runs-on: ubuntu-latest

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,52 @@
+# Loadtest observability
+
+The kind-based loadtests (`kind-stack-loadtest.sh`, `kind-ha-loadtest.sh`, run by
+the `loadtest-stack` / `loadtest-ha` jobs in `.github/workflows/test.yaml`) capture
+engine-side OpenTelemetry traces and a KPI summary from each run so a slow or
+failing run can be inspected after the fact and compared across runs.
+
+## How it works
+
+1. `loadtest-otel.yaml` deploys a throwaway **Jaeger all-in-one** (in-memory) into
+   the loadtest namespace as an OTLP sink.
+2. The released Hatchet engine is pointed at it purely through Helm values —
+   `--set sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317` (plus
+   `SERVER_OTEL_INSECURE`, `SERVER_OTEL_SERVICE_NAME=hatchet`,
+   `SERVER_OTEL_TRACE_ID_RATIO=1`). The chart range-renders `sharedConfig.env` into
+   the shared-config Secret every backend loads via `envFrom`, so no chart change
+   is needed. This captures engine-internal spans: `ingest-event` → scheduler
+   `handle-check-queue` → dispatcher `send-to-worker` → `otelpgx` DB queries,
+   stitched across services via the message-queue `otel_carrier`.
+3. After the loadtest pod completes, the script exports the traces and KPIs to the
+   runner filesystem **before** the namespace is torn down, and the workflow
+   uploads them as artifacts (`loadtest-stack-<version>` / `loadtest-ha-<version>`).
+
+## Artifacts
+
+- `loadtest-traces.json` — Jaeger-native trace export (engine service `hatchet`).
+- `loadtest-summary.json` — parsed KPIs: `averageDuration` (avg task execution
+  duration — the gated metric), `averageScheduling` (avg per-event scheduling
+  time), `counts` (pushed/executed/uniques), `result`, `version`, `scenario`.
+- `loadtest-logs.txt` — full loadtest pod logs.
+
+Each run's KPI row is also written to the GitHub Actions job summary for an
+at-a-glance comparison.
+
+## Viewing the traces
+
+Download `loadtest-traces.json` from the run's artifacts, then:
+
+```sh
+docker run --rm -p16686:16686 jaegertracing/all-in-one
+```
+
+Open <http://localhost:16686>, click **Upload** (JSON File) on the search page, and
+select `loadtest-traces.json`. The engine spans render as a waterfall showing where
+scheduling/execution latency was spent.
+
+## Analyzing regressions
+
+Download the `loadtest-*-<version>` artifacts from two runs and compare
+`loadtest-summary.json` (KPI drift) and the trace waterfalls (where the added
+latency lives). See the "Later / natural evolution" notes in the plan for pushing
+summaries to a persistent backend to trend KPIs by version over time.

--- a/hack/README.md
+++ b/hack/README.md
@@ -12,14 +12,17 @@ failing run can be inspected after the fact and compared across runs.
 2. The released Hatchet engine is pointed at it purely through Helm values —
    `--set sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317` (plus
    `SERVER_OTEL_INSECURE`, `SERVER_OTEL_SERVICE_NAME=hatchet`,
-   `SERVER_OTEL_TRACE_ID_RATIO=1`). The chart range-renders `sharedConfig.env` into
-   the shared-config Secret every backend loads via `envFrom`, so no chart change
-   is needed. This captures engine-internal spans: `ingest-event` → scheduler
-   `handle-check-queue` → dispatcher `send-to-worker` → `otelpgx` DB queries,
-   stitched across services via the message-queue `otel_carrier`.
-3. After the loadtest pod completes, the script exports the traces and KPIs to the
-   runner filesystem **before** the namespace is torn down, and the workflow
-   uploads them as artifacts (`loadtest-stack-<version>` / `loadtest-ha-<version>`).
+   `SERVER_OTEL_TRACE_ID_RATIO=0.5` — head-sampled at 50%, so traces stay complete
+   while halving the volume the engine emits). The chart range-renders
+   `sharedConfig.env` into the shared-config Secret every backend loads via
+   `envFrom`, so no chart change is needed. This captures engine-internal spans:
+   `ingest-event` → scheduler `handle-check-queue` → dispatcher `send-to-worker` →
+   `otelpgx` DB queries, stitched across services via the message-queue `otel_carrier`.
+3. After the loadtest pod completes, the script **polls** Jaeger's search API until
+   the engine's async batch export has flushed spans in (it can lag the run by up to
+   a minute), then writes the trace JSON + KPI summary to the runner **before** the
+   namespace is torn down. The workflow uploads them as artifacts
+   (`loadtest-stack-<version>` / `loadtest-ha-<version>`).
 
 ## Artifacts
 
@@ -37,7 +40,7 @@ at-a-glance comparison.
 Download `loadtest-traces.json` from the run's artifacts, then:
 
 ```sh
-docker run --rm -p16686:16686 jaegertracing/all-in-one
+docker run --rm -p 16686:16686 jaegertracing/all-in-one
 ```
 
 Open <http://localhost:16686>, click **Upload** (JSON File) on the search page, and

--- a/hack/kind-ha-loadtest.sh
+++ b/hack/kind-ha-loadtest.sh
@@ -260,11 +260,19 @@ fi
 # cleanup trap deletes the namespace.
 echo "Exporting engine traces from Jaeger..."
 # Give the engine's OTLP BatchSpanProcessor time to flush before we query.
-sleep 8
-kubectl port-forward -n loadtest svc/jaeger 16686:16686 > /dev/null 2>&1 &
+sleep 10
+kubectl port-forward -n loadtest svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
 JAEGER_PF_PID=$!
-sleep 3
-curl -sS "http://localhost:16686/api/traces?service=hatchet&limit=500&lookback=1h" \
+# Wait (up to ~30s) for the port-forward tunnel to actually accept connections —
+# a fixed sleep races against a busy CI runner and silently drops the export.
+for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
+    sleep 1
+done
+echo "Jaeger services recorded (expect 'hatchet' if the engine exported):"
+curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
+echo
+curl -sS --max-time 30 "http://localhost:16686/api/traces?service=hatchet&limit=1000&lookback=1h" \
     -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
 kill "$JAEGER_PF_PID" 2>/dev/null || true
 if [[ -s /tmp/loadtest-traces.json ]]; then

--- a/hack/kind-ha-loadtest.sh
+++ b/hack/kind-ha-loadtest.sh
@@ -95,9 +95,21 @@ echo "VERSION: $VERSION"
 
 helm dependency build charts/hatchet-ha
 
+# Create the namespace up front so the in-cluster OTel collector (Jaeger) and the
+# engine share it, and the collector is reachable before the engine starts exporting.
+kubectl create namespace loadtest --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Deploying in-cluster Jaeger (OTLP trace sink)..."
+kubectl apply -n loadtest -f hack/loadtest-otel.yaml
+kubectl rollout status deployment/jaeger -n loadtest --timeout=120s || echo "WARNING: Jaeger not ready; engine traces may be unavailable"
+
 helm install hatchet-ha-test charts/hatchet-ha \
     --create-namespace \
     --namespace loadtest \
+    --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
+    --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
+    --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
+    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=1 \
     --set sharedConfig.grpcBroadcastAddress="hatchet-grpc:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -241,6 +253,53 @@ else
             LOAD_TEST_EXIT_CODE=1
         fi
     fi
+fi
+
+# --- Export engine traces + KPI summary as CI artifacts (best-effort) ---
+# Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
+# cleanup trap deletes the namespace.
+echo "Exporting engine traces from Jaeger..."
+# Give the engine's OTLP BatchSpanProcessor time to flush before we query.
+sleep 8
+kubectl port-forward -n loadtest svc/jaeger 16686:16686 > /dev/null 2>&1 &
+JAEGER_PF_PID=$!
+sleep 3
+curl -sS "http://localhost:16686/api/traces?service=hatchet&limit=500&lookback=1h" \
+    -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
+kill "$JAEGER_PF_PID" 2>/dev/null || true
+if [[ -s /tmp/loadtest-traces.json ]]; then
+    TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)
+else
+    TRACE_COUNT=0
+fi
+echo "Exported ~${TRACE_COUNT} trace references to /tmp/loadtest-traces.json"
+
+# Parse the loadtest binary's own summary lines into a machine-readable summary.
+AVG_DURATION=$(grep -oE 'final average duration per executed event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")
+AVG_SCHEDULING=$(grep -oE 'final average scheduling time per event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")
+COUNTS_LINE=$(grep -oE 'pushed [0-9]+, executed [0-9]+, uniques [0-9]+[^)]*\)' /tmp/loadtest-logs.txt | tail -1 || echo "")
+cat > /tmp/loadtest-summary.json <<JSON
+{
+  "scenario": "ha",
+  "version": "${VERSION}",
+  "result": "${LOAD_TEST_STATUS}",
+  "averageDuration": "${AVG_DURATION}",
+  "averageScheduling": "${AVG_SCHEDULING}",
+  "counts": "${COUNTS_LINE}"
+}
+JSON
+echo "Wrote /tmp/loadtest-summary.json:"
+cat /tmp/loadtest-summary.json
+
+# One-line summary for the GitHub Actions run summary (no-op locally).
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "### Loadtest (ha) — ${VERSION}"
+        echo ""
+        echo "| Result | Avg duration | Avg scheduling | Counts |"
+        echo "| --- | --- | --- | --- |"
+        echo "| ${LOAD_TEST_STATUS} | ${AVG_DURATION:-n/a} | ${AVG_SCHEDULING:-n/a} | ${COUNTS_LINE:-n/a} |"
+    } >> "$GITHUB_STEP_SUMMARY"
 fi
 
 # Clean up pod

--- a/hack/kind-ha-loadtest.sh
+++ b/hack/kind-ha-loadtest.sh
@@ -109,7 +109,7 @@ helm install hatchet-ha-test charts/hatchet-ha \
     --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
     --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
     --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
-    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=1 \
+    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5 \
     --set sharedConfig.grpcBroadcastAddress="hatchet-grpc:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -259,21 +259,34 @@ fi
 # Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
 # cleanup trap deletes the namespace.
 echo "Exporting engine traces from Jaeger..."
-# Give the engine's OTLP BatchSpanProcessor time to flush before we query.
-sleep 10
 kubectl port-forward -n loadtest svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
 JAEGER_PF_PID=$!
-# Wait (up to ~30s) for the port-forward tunnel to actually accept connections —
-# a fixed sleep races against a busy CI runner and silently drops the export.
+# Wait (up to ~30s) for the port-forward tunnel to actually accept connections.
 for _ in $(seq 1 30); do
     if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
     sleep 1
 done
-echo "Jaeger services recorded (expect 'hatchet' if the engine exported):"
+echo "Jaeger services recorded (expect 'hatchet' once the engine has exported):"
 curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
 echo
-curl -sS --max-time 30 "http://localhost:16686/api/traces?service=hatchet&limit=1000&lookback=1h" \
-    -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
+# The engine's OTLP BatchSpanProcessor flushes to Jaeger asynchronously and can lag
+# the loadtest finishing by up to a minute, so poll the search until traces actually
+# appear rather than guessing a fixed sleep. Use a wide start/end window (micros) so
+# host/container clock skew can't hide the spans; /api/traces requires explicit bounds.
+NOW_US=$(( $(date +%s) * 1000000 ))
+START_US=$(( NOW_US - 24 * 3600 * 1000000 ))
+END_US=$(( NOW_US + 3600 * 1000000 ))
+TRACES_URL="http://localhost:16686/api/traces?service=hatchet&start=${START_US}&end=${END_US}&limit=1500"
+for attempt in $(seq 1 24); do
+    curl -sS --max-time 60 "$TRACES_URL" -o /tmp/loadtest-traces.json 2>/dev/null || true
+    SPAN_REFS=$(grep -o '"traceID"' /tmp/loadtest-traces.json 2>/dev/null | wc -l | tr -d ' ' || true)
+    if [[ "${SPAN_REFS:-0}" -gt 0 ]]; then
+        echo "Trace export succeeded on attempt ${attempt} (~${SPAN_REFS} span refs)"
+        break
+    fi
+    echo "Attempt ${attempt}: engine still flushing spans to Jaeger; retrying in 5s..."
+    sleep 5
+done
 kill "$JAEGER_PF_PID" 2>/dev/null || true
 if [[ -s /tmp/loadtest-traces.json ]]; then
     TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)

--- a/hack/kind-stack-loadtest.sh
+++ b/hack/kind-stack-loadtest.sh
@@ -260,11 +260,19 @@ fi
 # cleanup trap deletes the namespace.
 echo "Exporting engine traces from Jaeger..."
 # Give the engine's OTLP BatchSpanProcessor time to flush before we query.
-sleep 8
-kubectl port-forward -n loadtest-stack svc/jaeger 16686:16686 > /dev/null 2>&1 &
+sleep 10
+kubectl port-forward -n loadtest-stack svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
 JAEGER_PF_PID=$!
-sleep 3
-curl -sS "http://localhost:16686/api/traces?service=hatchet&limit=500&lookback=1h" \
+# Wait (up to ~30s) for the port-forward tunnel to actually accept connections —
+# a fixed sleep races against a busy CI runner and silently drops the export.
+for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
+    sleep 1
+done
+echo "Jaeger services recorded (expect 'hatchet' if the engine exported):"
+curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
+echo
+curl -sS --max-time 30 "http://localhost:16686/api/traces?service=hatchet&limit=1000&lookback=1h" \
     -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
 kill "$JAEGER_PF_PID" 2>/dev/null || true
 if [[ -s /tmp/loadtest-traces.json ]]; then

--- a/hack/kind-stack-loadtest.sh
+++ b/hack/kind-stack-loadtest.sh
@@ -95,9 +95,21 @@ echo "VERSION: $VERSION"
 
 helm dependency build charts/hatchet-stack
 
+# Create the namespace up front so the in-cluster OTel collector (Jaeger) and the
+# engine share it, and the collector is reachable before the engine starts exporting.
+kubectl create namespace loadtest-stack --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Deploying in-cluster Jaeger (OTLP trace sink)..."
+kubectl apply -n loadtest-stack -f hack/loadtest-otel.yaml
+kubectl rollout status deployment/jaeger -n loadtest-stack --timeout=120s || echo "WARNING: Jaeger not ready; engine traces may be unavailable"
+
 helm install hatchet-stack-test charts/hatchet-stack \
     --create-namespace \
     --namespace loadtest-stack \
+    --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
+    --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
+    --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
+    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=1 \
     --set sharedConfig.grpcBroadcastAddress="hatchet-stack-test-engine:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -241,6 +253,53 @@ else
             LOAD_TEST_EXIT_CODE=1
         fi
     fi
+fi
+
+# --- Export engine traces + KPI summary as CI artifacts (best-effort) ---
+# Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
+# cleanup trap deletes the namespace.
+echo "Exporting engine traces from Jaeger..."
+# Give the engine's OTLP BatchSpanProcessor time to flush before we query.
+sleep 8
+kubectl port-forward -n loadtest-stack svc/jaeger 16686:16686 > /dev/null 2>&1 &
+JAEGER_PF_PID=$!
+sleep 3
+curl -sS "http://localhost:16686/api/traces?service=hatchet&limit=500&lookback=1h" \
+    -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
+kill "$JAEGER_PF_PID" 2>/dev/null || true
+if [[ -s /tmp/loadtest-traces.json ]]; then
+    TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)
+else
+    TRACE_COUNT=0
+fi
+echo "Exported ~${TRACE_COUNT} trace references to /tmp/loadtest-traces.json"
+
+# Parse the loadtest binary's own summary lines into a machine-readable summary.
+AVG_DURATION=$(grep -oE 'final average duration per executed event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")
+AVG_SCHEDULING=$(grep -oE 'final average scheduling time per event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")
+COUNTS_LINE=$(grep -oE 'pushed [0-9]+, executed [0-9]+, uniques [0-9]+[^)]*\)' /tmp/loadtest-logs.txt | tail -1 || echo "")
+cat > /tmp/loadtest-summary.json <<JSON
+{
+  "scenario": "stack",
+  "version": "${VERSION}",
+  "result": "${LOAD_TEST_STATUS}",
+  "averageDuration": "${AVG_DURATION}",
+  "averageScheduling": "${AVG_SCHEDULING}",
+  "counts": "${COUNTS_LINE}"
+}
+JSON
+echo "Wrote /tmp/loadtest-summary.json:"
+cat /tmp/loadtest-summary.json
+
+# One-line summary for the GitHub Actions run summary (no-op locally).
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "### Loadtest (stack) — ${VERSION}"
+        echo ""
+        echo "| Result | Avg duration | Avg scheduling | Counts |"
+        echo "| --- | --- | --- | --- |"
+        echo "| ${LOAD_TEST_STATUS} | ${AVG_DURATION:-n/a} | ${AVG_SCHEDULING:-n/a} | ${COUNTS_LINE:-n/a} |"
+    } >> "$GITHUB_STEP_SUMMARY"
 fi
 
 # Clean up pod

--- a/hack/kind-stack-loadtest.sh
+++ b/hack/kind-stack-loadtest.sh
@@ -109,7 +109,7 @@ helm install hatchet-stack-test charts/hatchet-stack \
     --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
     --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
     --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
-    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=1 \
+    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5 \
     --set sharedConfig.grpcBroadcastAddress="hatchet-stack-test-engine:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -259,21 +259,34 @@ fi
 # Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
 # cleanup trap deletes the namespace.
 echo "Exporting engine traces from Jaeger..."
-# Give the engine's OTLP BatchSpanProcessor time to flush before we query.
-sleep 10
 kubectl port-forward -n loadtest-stack svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
 JAEGER_PF_PID=$!
-# Wait (up to ~30s) for the port-forward tunnel to actually accept connections —
-# a fixed sleep races against a busy CI runner and silently drops the export.
+# Wait (up to ~30s) for the port-forward tunnel to actually accept connections.
 for _ in $(seq 1 30); do
     if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
     sleep 1
 done
-echo "Jaeger services recorded (expect 'hatchet' if the engine exported):"
+echo "Jaeger services recorded (expect 'hatchet' once the engine has exported):"
 curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
 echo
-curl -sS --max-time 30 "http://localhost:16686/api/traces?service=hatchet&limit=1000&lookback=1h" \
-    -o /tmp/loadtest-traces.json || echo "WARNING: failed to export traces from Jaeger"
+# The engine's OTLP BatchSpanProcessor flushes to Jaeger asynchronously and can lag
+# the loadtest finishing by up to a minute, so poll the search until traces actually
+# appear rather than guessing a fixed sleep. Use a wide start/end window (micros) so
+# host/container clock skew can't hide the spans; /api/traces requires explicit bounds.
+NOW_US=$(( $(date +%s) * 1000000 ))
+START_US=$(( NOW_US - 24 * 3600 * 1000000 ))
+END_US=$(( NOW_US + 3600 * 1000000 ))
+TRACES_URL="http://localhost:16686/api/traces?service=hatchet&start=${START_US}&end=${END_US}&limit=1500"
+for attempt in $(seq 1 24); do
+    curl -sS --max-time 60 "$TRACES_URL" -o /tmp/loadtest-traces.json 2>/dev/null || true
+    SPAN_REFS=$(grep -o '"traceID"' /tmp/loadtest-traces.json 2>/dev/null | wc -l | tr -d ' ' || true)
+    if [[ "${SPAN_REFS:-0}" -gt 0 ]]; then
+        echo "Trace export succeeded on attempt ${attempt} (~${SPAN_REFS} span refs)"
+        break
+    fi
+    echo "Attempt ${attempt}: engine still flushing spans to Jaeger; retrying in 5s..."
+    sleep 5
+done
 kill "$JAEGER_PF_PID" 2>/dev/null || true
 if [[ -s /tmp/loadtest-traces.json ]]; then
     TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)

--- a/hack/loadtest-otel.yaml
+++ b/hack/loadtest-otel.yaml
@@ -1,0 +1,64 @@
+# Throwaway Jaeger all-in-one used only by the kind loadtests (hack/kind-*-loadtest.sh)
+# as an in-cluster OTLP sink for the engine's OpenTelemetry export. The engine is
+# pointed at svc `jaeger:4317` via `--set sharedConfig.env.SERVER_OTEL_COLLECTOR_URL`.
+# After a run the scripts export the collected traces (Jaeger JSON) as a CI artifact.
+# In-memory storage only — the cluster is torn down after every run.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  labels:
+    app: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:1.76.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: query
+              containerPort: 16686
+            - name: admin
+              containerPort: 14269
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  labels:
+    app: jaeger
+spec:
+  selector:
+    app: jaeger
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: query
+      port: 16686
+      targetPort: 16686

--- a/hack/loadtest-otel.yaml
+++ b/hack/loadtest-otel.yaml
@@ -42,9 +42,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
-            limits:
               memory: 512Mi
+            limits:
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
# Description

Adds a `jaegar` sink for OTel traces when loadtests are run on PRs. This is to analyze any and all regressions whenever we are updating the charts.

Artifacts are uploaded to each GitHub workflow run and can be downloaded to visualize locally with Jaegar.

First step towards understanding https://github.com/hatchet-dev/hatchet-charts/issues/54

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] CI (any automation pipeline changes)
