### PR TITLE
feat(hatchet-api): optional stable-named Helm hooks for install jobs

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-09-04
+
+- Add an opt-in `installJobsAsHooks` flag (default `false`). When enabled, the setup and worker-token Jobs render as pre-install/pre-upgrade Helm hooks with stable names and `before-hook-creation` delete policy, and their Role/RoleBinding become lower-weight hooks. This avoids the perpetual drift and orphaned Jobs GitOps tools (e.g. ArgoCD) see with the default randomly-named Jobs.
+
 ## [0.17.0] - 2026-08-31
 
 - Update the default Hatchet image to [`v0.105.16`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.105.16) for the API, setup, migration and seed Jobs.

--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.17.0
+version: 0.18.0
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -73,6 +73,12 @@ metadata:
   name: {{ template "hatchet.fullname" . }}
   labels:
 {{- include "hatchet.labels" . | nindent 4 }}
+  {{- if .Values.installJobsAsHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps", "secrets"]
@@ -84,6 +90,12 @@ metadata:
   name: {{ template "hatchet.fullname" . }}
   labels:
 {{- include "hatchet.labels" . | nindent 4 }}
+  {{- if .Values.installJobsAsHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -96,9 +108,23 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.installJobsAsHooks }}
+  name: {{ template "hatchet.fullname" . }}-setup
+  {{- else }}
   name: "{{ .Release.Name | trunc 20 }}-{{ randAlphaNum 10 | lower }}"
+  {{- end }}
   labels:
 {{- include "hatchet.labels" . | nindent 4 }}
+  {{- if .Values.installJobsAsHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    {{- if .Values.retainFailedHooks }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- else }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    {{- end }}
+  {{- end }}
 spec:
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
@@ -212,9 +238,23 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.installJobsAsHooks }}
+  name: {{ template "hatchet.fullname" . }}-worker-token
+  {{- else }}
   name: "{{ .Release.Name | trunc 20 }}-{{ randAlphaNum 10 | lower }}-worker-token"
+  {{- end }}
   labels:
 {{- include "hatchet.labels" . | nindent 4 }}
+  {{- if .Values.installJobsAsHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    {{- if .Values.retainFailedHooks }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- else }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    {{- end }}
+  {{- end }}
 spec:
   backoffLimit: 1
   activeDeadlineSeconds: 900

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -62,6 +62,13 @@ cloudSQLSidecar:
       cpu: 500m
       memory: 512Mi
 
+# Render the install-time setup and worker-token Jobs as Helm hooks with stable
+# names instead of the default plain resources with a random name suffix. Leave
+# false for a normal `helm install`/`upgrade` (unchanged behaviour). Set true for
+# GitOps tools (e.g. ArgoCD) that otherwise treat the randomly-named Jobs as a
+# brand-new resource on every reconcile, causing perpetual drift and orphaned Jobs.
+installJobsAsHooks: false
+
 # Retain failed Helm hook Jobs (currently the pre-upgrade migration hook) so logs survive for debugging.
 retainFailedHooks: true
 

--- a/charts/hatchet-ha/CHANGELOG.md
+++ b/charts/hatchet-ha/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-09-04
+
+- Bump the bundled `hatchet-api` subchart to `0.18.0` (adds the opt-in `installJobsAsHooks` flag).
+
 ## [0.17.0] - 2026-08-31
 
 - Update the default Hatchet image to [`v0.105.16`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.105.16).

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
   version: 0.17.0
@@ -20,5 +20,5 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:e0d49cf958e59855b3883874ac3fae955ac5d94d548084d1cae0feccc727c70f
-generated: "2026-08-31T21:29:10.282807732Z"
+digest: sha256:4dd10a12c5a2ff992f26ebc90b7da9ab140aa8b15dccf0a760511fe0e5e4c3e2
+generated: "2026-09-04T23:58:41.981851-04:00"

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.17.0
+version: 0.18.0
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -28,22 +28,22 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled

--- a/charts/hatchet-stack/CHANGELOG.md
+++ b/charts/hatchet-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-09-04
+
+- Bump the bundled `hatchet-api` subchart to `0.18.0` (adds the opt-in `installJobsAsHooks` flag).
+
 ## [0.17.0] - 2026-08-31
 
 - Update the default Hatchet image to [`v0.105.16`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.105.16).

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.17.0
+  version: 0.18.0
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
   version: 0.17.0
@@ -14,5 +14,5 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:ccdb392e4b5ccf12021d3b02cfc4b5c41264a9034cff572d59c58af7afd70b44
-generated: "2026-08-31T21:29:27.099689369Z"
+digest: sha256:0636d22854fad334b3cfed6d7644cd473305f43d051940353aa7f532a6f58055
+generated: "2026-09-04T23:58:51.065958-04:00"

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.17.0
+version: 0.18.0
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -27,12 +27,12 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "0.17.0"
+    version: "0.18.0"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled


### PR DESCRIPTION
## Problem

The setup and worker-token Jobs (`charts/hatchet-api/templates/setup-job.yaml`) are plain resources named with a `randAlphaNum` suffix, so they render a new name on every template pass. GitOps controllers like ArgoCD always render with `.Release.IsInstall=true`, so they see a **brand-new Job on every reconcile** — producing perpetual drift and a pile of orphaned Jobs in the namespace.

## Change

Adds an opt-in `installJobsAsHooks` flag (**default `false` → no behaviour change** for a normal `helm install`/`upgrade`).

When `true`:
- the setup and worker-token Jobs get **stable names** (`<fullname>-setup`, `<fullname>-worker-token`)
- they gain `pre-install,pre-upgrade` hook annotations with a `before-hook-creation` delete policy (respecting `retainFailedHooks`)
- their `Role`/`RoleBinding` become hooks at a lower weight so RBAC exists before the Jobs run

This mirrors the existing `pre-upgrade` migration hook and lets GitOps users deploy without drift or orphaned Jobs.

## Note for maintainers

With the flag on, the setup Job runs at hook time referencing the chart ServiceAccount (a normal resource). This matches the assumption the existing `pre-upgrade` migration hook already makes. Happy to also gate the ServiceAccount as a hook if you'd prefer full first-`helm install` coverage.

## Testing

- `helm lint` clean
- default render: random names, no hook annotations (unchanged)
- `installJobsAsHooks=true` render: stable names + hooks on Role, RoleBinding, setup Job, worker-token Job