### PR TITLE
chore: send loadtest traces to ClickStack

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -395,14 +395,16 @@ jobs:
           ./hack/kind-stack-loadtest.sh
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
+          CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_ENDPOINT }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
 
-      - name: Upload loadtest traces & summary
+      - name: Upload loadtest summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: loadtest-stack-${{ needs.resolve-version.outputs.version }}
           path: |
-            /tmp/loadtest-traces.json
             /tmp/loadtest-summary.json
             /tmp/loadtest-logs.txt
           if-no-files-found: warn
@@ -444,14 +446,16 @@ jobs:
           ./hack/kind-ha-loadtest.sh
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
+          CLICKHOUSE_ENDPOINT: ${{ secrets.CLICKHOUSE_ENDPOINT }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
 
-      - name: Upload loadtest traces & summary
+      - name: Upload loadtest summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: loadtest-ha-${{ needs.resolve-version.outputs.version }}
           path: |
-            /tmp/loadtest-traces.json
             /tmp/loadtest-summary.json
             /tmp/loadtest-logs.txt
           if-no-files-found: warn

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,32 +1,40 @@
 # Loadtest observability
 
 The kind-based loadtests (`kind-stack-loadtest.sh`, `kind-ha-loadtest.sh`, run by
-the `loadtest-stack` / `loadtest-ha` jobs in `.github/workflows/test.yaml`) capture
-engine-side OpenTelemetry traces and a KPI summary from each run so a slow or
-failing run can be inspected after the fact and compared across runs.
+the `loadtest-stack` / `loadtest-ha` jobs in `.github/workflows/test.yaml`) export
+engine-side OpenTelemetry traces to **ClickStack Cloud** and write a KPI summary from
+each run, so a slow or failing run can be inspected after the fact and compared
+across runs.
 
 ## How it works
 
-1. `loadtest-otel.yaml` deploys a throwaway **Jaeger all-in-one** (in-memory) into
-   the loadtest namespace as an OTLP sink.
-2. The released Hatchet engine is pointed at it purely through Helm values —
-   `--set sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317` (plus
-   `SERVER_OTEL_INSECURE`, `SERVER_OTEL_SERVICE_NAME=hatchet`,
-   `SERVER_OTEL_TRACE_ID_RATIO=0.5` — head-sampled at 50%, so traces stay complete
-   while halving the volume the engine emits). The chart range-renders
-   `sharedConfig.env` into the shared-config Secret every backend loads via
-   `envFrom`, so no chart change is needed. This captures engine-internal spans:
-   `ingest-event` → scheduler `handle-check-queue` → dispatcher `send-to-worker` →
-   `otelpgx` DB queries, stitched across services via the message-queue `otel_carrier`.
-3. After the loadtest pod completes, the script **polls** Jaeger's search API until
-   the engine's async batch export has flushed spans in (it can lag the run by up to
-   a minute), then writes the trace JSON + KPI summary to the runner **before** the
-   namespace is torn down. The workflow uploads them as artifacts
-   (`loadtest-stack-<version>` / `loadtest-ha-<version>`).
+1. `loadtest-otel.yaml` deploys an in-cluster **ClickStack OTel collector**
+   (`clickhouse/clickstack-otel-collector`) into the loadtest namespace as the OTLP
+   sink. It receives spans on `otel-collector:4317` and forwards them to ClickHouse
+   Cloud over TLS using the credentials in the `clickstack-otel` Secret (which the
+   scripts create from GitHub secrets).
+2. The released Hatchet engine is pointed at the collector purely through Helm values —
+   `SERVER_OTEL_COLLECTOR_URL=otel-collector:4317` with `SERVER_OTEL_INSECURE=true`
+   (in-cluster, plaintext — the collector, not the engine, holds the ClickHouse
+   credentials). Traces are head-sampled at 50% (`SERVER_OTEL_TRACE_ID_RATIO=0.5`) so
+   they stay complete while halving the volume the engine emits, and each scenario
+   reports under its own service name (`hatchet-loadtest-stack` / `hatchet-loadtest-ha`)
+   so runs are separable in the ClickStack UI. The chart range-renders
+   `sharedConfig.env` into the shared-config Secret every backend loads via `envFrom`,
+   so no chart change is needed. This captures engine-internal spans: `ingest-event` →
+   scheduler `handle-check-queue` → dispatcher `send-to-worker` → `otelpgx` DB queries,
+   stitched across services via the message-queue `otel_carrier`.
+3. The collector's ClickHouse Cloud credentials come from the `CLICKHOUSE_ENDPOINT`,
+   `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` GitHub secrets, passed to the scripts as
+   env vars. When any is unset the collector is skipped and the engine's OTLP export is
+   a no-op, so local runs work without any secrets (you just get no traces).
+4. Traces flush asynchronously to ClickHouse Cloud during and shortly after the run;
+   there is nothing to export from the cluster, so the namespace is torn down as soon as
+   the run finishes. In the ClickStack (HyperDX) UI, add a source pointing at the same
+   ClickHouse Cloud instance to query them.
 
 ## Artifacts
 
-- `loadtest-traces.json` — Jaeger-native trace export (engine service `hatchet`).
 - `loadtest-summary.json` — parsed KPIs: `averageDuration` (avg task execution
   duration — the gated metric), `averageScheduling` (avg per-event scheduling
   time), `counts` (pushed/executed/uniques), `result`, `version`, `scenario`.
@@ -37,19 +45,13 @@ at-a-glance comparison.
 
 ## Viewing the traces
 
-Download `loadtest-traces.json` from the run's artifacts, then:
-
-```sh
-docker run --rm -p 16686:16686 jaegertracing/all-in-one
-```
-
-Open <http://localhost:16686>, click **Upload** (JSON File) on the search page, and
-select `loadtest-traces.json`. The engine spans render as a waterfall showing where
-scheduling/execution latency was spent.
+Open the ClickStack Cloud UI and search for the run's service
+(`hatchet-loadtest-stack` or `hatchet-loadtest-ha`), narrowed to the run's time
+window. The engine spans render as a waterfall showing where scheduling/execution
+latency was spent.
 
 ## Analyzing regressions
 
-Download the `loadtest-*-<version>` artifacts from two runs and compare
-`loadtest-summary.json` (KPI drift) and the trace waterfalls (where the added
-latency lives). See the "Later / natural evolution" notes in the plan for pushing
-summaries to a persistent backend to trend KPIs by version over time.
+Compare `loadtest-summary.json` across two runs' `loadtest-*-<version>` artifacts
+(KPI drift), then open the corresponding trace waterfalls in ClickStack Cloud to see
+where the added latency lives.

--- a/hack/kind-ha-loadtest.sh
+++ b/hack/kind-ha-loadtest.sh
@@ -95,21 +95,46 @@ echo "VERSION: $VERSION"
 
 helm dependency build charts/hatchet-ha
 
-# Create the namespace up front so the in-cluster OTel collector (Jaeger) and the
-# engine share it, and the collector is reachable before the engine starts exporting.
+# Create the namespace up front so the engine has somewhere to land before install.
 kubectl create namespace loadtest --dry-run=client -o yaml | kubectl apply -f -
 
-echo "Deploying in-cluster Jaeger (OTLP trace sink)..."
-kubectl apply -n loadtest -f hack/loadtest-otel.yaml
-kubectl rollout status deployment/jaeger -n loadtest --timeout=120s || echo "WARNING: Jaeger not ready; engine traces may be unavailable"
+# Engine traces are shipped to ClickStack Cloud via an in-cluster ClickStack OTel
+# collector: the engine exports OTLP to svc `otel-collector:4317` (plaintext,
+# in-cluster) and the collector forwards spans to ClickHouse Cloud over TLS using the
+# credentials below (provided via GitHub secrets in CI). When any credential is unset
+# the collector is skipped and the engine's OTLP export is a no-op, so local runs work
+# without any secrets.
+otel_args=()
+if [[ -n "${CLICKHOUSE_ENDPOINT:-}" && -n "${CLICKHOUSE_USER:-}" && -n "${CLICKHOUSE_PASSWORD:-}" ]]; then
+    # Wake the ClickHouse Cloud service before the collector starts writing. A
+    # scaled-to-zero instance resumes on any HTTP hit; poll /ping until it's back
+    # (up to ~60s). Mirrors the wake-clickhouse job in hatchet-cloud's build.yml.
+    echo "Waking ClickHouse Cloud (${CLICKHOUSE_ENDPOINT%/}/ping)..."
+    curl -sS --retry 30 --retry-delay 2 --retry-all-errors "${CLICKHOUSE_ENDPOINT%/}/ping" \
+        || echo "WARNING: ClickHouse wake ping failed; collector writes may lag until it resumes"
+
+    echo "Deploying in-cluster ClickStack OTel collector (ships traces to ClickHouse Cloud)..."
+    kubectl create secret generic clickstack-otel -n loadtest \
+        --from-literal=CLICKHOUSE_ENDPOINT="${CLICKHOUSE_ENDPOINT}" \
+        --from-literal=CLICKHOUSE_USER="${CLICKHOUSE_USER}" \
+        --from-literal=CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    kubectl apply -n loadtest -f hack/loadtest-otel.yaml
+    kubectl rollout status deployment/otel-collector -n loadtest --timeout=120s || echo "WARNING: collector not ready; engine traces may be unavailable"
+    otel_args=(
+        --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=otel-collector:4317
+        --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true
+        --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet-loadtest-ha
+        --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5
+    )
+else
+    echo "CLICKHOUSE_ENDPOINT / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD not set; engine trace export disabled."
+fi
 
 helm install hatchet-ha-test charts/hatchet-ha \
     --create-namespace \
     --namespace loadtest \
-    --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
-    --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
-    --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
-    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5 \
+    ${otel_args[@]+"${otel_args[@]}"} \
     --set sharedConfig.grpcBroadcastAddress="hatchet-grpc:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -255,45 +280,12 @@ else
     fi
 fi
 
-# --- Export engine traces + KPI summary as CI artifacts (best-effort) ---
-# Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
-# cleanup trap deletes the namespace.
-echo "Exporting engine traces from Jaeger..."
-kubectl port-forward -n loadtest svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
-JAEGER_PF_PID=$!
-# Wait (up to ~30s) for the port-forward tunnel to actually accept connections.
-for _ in $(seq 1 30); do
-    if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
-    sleep 1
-done
-echo "Jaeger services recorded (expect 'hatchet' once the engine has exported):"
-curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
-echo
-# The engine's OTLP BatchSpanProcessor flushes to Jaeger asynchronously and can lag
-# the loadtest finishing by up to a minute, so poll the search until traces actually
-# appear rather than guessing a fixed sleep. Use a wide start/end window (micros) so
-# host/container clock skew can't hide the spans; /api/traces requires explicit bounds.
-NOW_US=$(( $(date +%s) * 1000000 ))
-START_US=$(( NOW_US - 24 * 3600 * 1000000 ))
-END_US=$(( NOW_US + 3600 * 1000000 ))
-TRACES_URL="http://localhost:16686/api/traces?service=hatchet&start=${START_US}&end=${END_US}&limit=1500"
-for attempt in $(seq 1 24); do
-    curl -sS --max-time 60 "$TRACES_URL" -o /tmp/loadtest-traces.json 2>/dev/null || true
-    SPAN_REFS=$(grep -o '"traceID"' /tmp/loadtest-traces.json 2>/dev/null | wc -l | tr -d ' ' || true)
-    if [[ "${SPAN_REFS:-0}" -gt 0 ]]; then
-        echo "Trace export succeeded on attempt ${attempt} (~${SPAN_REFS} span refs)"
-        break
-    fi
-    echo "Attempt ${attempt}: engine still flushing spans to Jaeger; retrying in 5s..."
-    sleep 5
-done
-kill "$JAEGER_PF_PID" 2>/dev/null || true
-if [[ -s /tmp/loadtest-traces.json ]]; then
-    TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)
-else
-    TRACE_COUNT=0
+# --- KPI summary as a CI artifact (best-effort) ---
+# Engine traces for this run live in ClickStack Cloud (service hatchet-loadtest-ha),
+# so there is nothing to export from the cluster before the cleanup trap tears it down.
+if [[ -n "${CLICKHOUSE_ENDPOINT:-}" ]]; then
+    echo "Engine traces exported to ClickStack Cloud (service: hatchet-loadtest-ha)."
 fi
-echo "Exported ~${TRACE_COUNT} trace references to /tmp/loadtest-traces.json"
 
 # Parse the loadtest binary's own summary lines into a machine-readable summary.
 AVG_DURATION=$(grep -oE 'final average duration per executed event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")

--- a/hack/kind-stack-loadtest.sh
+++ b/hack/kind-stack-loadtest.sh
@@ -95,21 +95,46 @@ echo "VERSION: $VERSION"
 
 helm dependency build charts/hatchet-stack
 
-# Create the namespace up front so the in-cluster OTel collector (Jaeger) and the
-# engine share it, and the collector is reachable before the engine starts exporting.
+# Create the namespace up front so the engine has somewhere to land before install.
 kubectl create namespace loadtest-stack --dry-run=client -o yaml | kubectl apply -f -
 
-echo "Deploying in-cluster Jaeger (OTLP trace sink)..."
-kubectl apply -n loadtest-stack -f hack/loadtest-otel.yaml
-kubectl rollout status deployment/jaeger -n loadtest-stack --timeout=120s || echo "WARNING: Jaeger not ready; engine traces may be unavailable"
+# Engine traces are shipped to ClickStack Cloud via an in-cluster ClickStack OTel
+# collector: the engine exports OTLP to svc `otel-collector:4317` (plaintext,
+# in-cluster) and the collector forwards spans to ClickHouse Cloud over TLS using the
+# credentials below (provided via GitHub secrets in CI). When any credential is unset
+# the collector is skipped and the engine's OTLP export is a no-op, so local runs work
+# without any secrets.
+otel_args=()
+if [[ -n "${CLICKHOUSE_ENDPOINT:-}" && -n "${CLICKHOUSE_USER:-}" && -n "${CLICKHOUSE_PASSWORD:-}" ]]; then
+    # Wake the ClickHouse Cloud service before the collector starts writing. A
+    # scaled-to-zero instance resumes on any HTTP hit; poll /ping until it's back
+    # (up to ~60s). Mirrors the wake-clickhouse job in hatchet-cloud's build.yml.
+    echo "Waking ClickHouse Cloud (${CLICKHOUSE_ENDPOINT%/}/ping)..."
+    curl -sS --retry 30 --retry-delay 2 --retry-all-errors "${CLICKHOUSE_ENDPOINT%/}/ping" \
+        || echo "WARNING: ClickHouse wake ping failed; collector writes may lag until it resumes"
+
+    echo "Deploying in-cluster ClickStack OTel collector (ships traces to ClickHouse Cloud)..."
+    kubectl create secret generic clickstack-otel -n loadtest-stack \
+        --from-literal=CLICKHOUSE_ENDPOINT="${CLICKHOUSE_ENDPOINT}" \
+        --from-literal=CLICKHOUSE_USER="${CLICKHOUSE_USER}" \
+        --from-literal=CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    kubectl apply -n loadtest-stack -f hack/loadtest-otel.yaml
+    kubectl rollout status deployment/otel-collector -n loadtest-stack --timeout=120s || echo "WARNING: collector not ready; engine traces may be unavailable"
+    otel_args=(
+        --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=otel-collector:4317
+        --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true
+        --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet-loadtest-stack
+        --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5
+    )
+else
+    echo "CLICKHOUSE_ENDPOINT / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD not set; engine trace export disabled."
+fi
 
 helm install hatchet-stack-test charts/hatchet-stack \
     --create-namespace \
     --namespace loadtest-stack \
-    --set-string sharedConfig.env.SERVER_OTEL_COLLECTOR_URL=jaeger:4317 \
-    --set-string sharedConfig.env.SERVER_OTEL_INSECURE=true \
-    --set-string sharedConfig.env.SERVER_OTEL_SERVICE_NAME=hatchet \
-    --set-string sharedConfig.env.SERVER_OTEL_TRACE_ID_RATIO=0.5 \
+    ${otel_args[@]+"${otel_args[@]}"} \
     --set sharedConfig.grpcBroadcastAddress="hatchet-stack-test-engine:7070" \
     --set postgres.primary.resources.limits.memory=1Gi \
     --set postgres.primary.resources.limits.cpu=500m \
@@ -255,45 +280,12 @@ else
     fi
 fi
 
-# --- Export engine traces + KPI summary as CI artifacts (best-effort) ---
-# Runs regardless of pass/fail (traces matter most on failure) and BEFORE the
-# cleanup trap deletes the namespace.
-echo "Exporting engine traces from Jaeger..."
-kubectl port-forward -n loadtest-stack svc/jaeger 16686:16686 > /tmp/jaeger-pf.log 2>&1 &
-JAEGER_PF_PID=$!
-# Wait (up to ~30s) for the port-forward tunnel to actually accept connections.
-for _ in $(seq 1 30); do
-    if curl -sf "http://localhost:16686/api/services" > /dev/null 2>&1; then break; fi
-    sleep 1
-done
-echo "Jaeger services recorded (expect 'hatchet' once the engine has exported):"
-curl -sS --max-time 15 "http://localhost:16686/api/services" || echo "  (failed to list services)"
-echo
-# The engine's OTLP BatchSpanProcessor flushes to Jaeger asynchronously and can lag
-# the loadtest finishing by up to a minute, so poll the search until traces actually
-# appear rather than guessing a fixed sleep. Use a wide start/end window (micros) so
-# host/container clock skew can't hide the spans; /api/traces requires explicit bounds.
-NOW_US=$(( $(date +%s) * 1000000 ))
-START_US=$(( NOW_US - 24 * 3600 * 1000000 ))
-END_US=$(( NOW_US + 3600 * 1000000 ))
-TRACES_URL="http://localhost:16686/api/traces?service=hatchet&start=${START_US}&end=${END_US}&limit=1500"
-for attempt in $(seq 1 24); do
-    curl -sS --max-time 60 "$TRACES_URL" -o /tmp/loadtest-traces.json 2>/dev/null || true
-    SPAN_REFS=$(grep -o '"traceID"' /tmp/loadtest-traces.json 2>/dev/null | wc -l | tr -d ' ' || true)
-    if [[ "${SPAN_REFS:-0}" -gt 0 ]]; then
-        echo "Trace export succeeded on attempt ${attempt} (~${SPAN_REFS} span refs)"
-        break
-    fi
-    echo "Attempt ${attempt}: engine still flushing spans to Jaeger; retrying in 5s..."
-    sleep 5
-done
-kill "$JAEGER_PF_PID" 2>/dev/null || true
-if [[ -s /tmp/loadtest-traces.json ]]; then
-    TRACE_COUNT=$(grep -o '"traceID"' /tmp/loadtest-traces.json | wc -l | tr -d ' ' || true)
-else
-    TRACE_COUNT=0
+# --- KPI summary as a CI artifact (best-effort) ---
+# Engine traces for this run live in ClickStack Cloud (service hatchet-loadtest-stack),
+# so there is nothing to export from the cluster before the cleanup trap tears it down.
+if [[ -n "${CLICKHOUSE_ENDPOINT:-}" ]]; then
+    echo "Engine traces exported to ClickStack Cloud (service: hatchet-loadtest-stack)."
 fi
-echo "Exported ~${TRACE_COUNT} trace references to /tmp/loadtest-traces.json"
 
 # Parse the loadtest binary's own summary lines into a machine-readable summary.
 AVG_DURATION=$(grep -oE 'final average duration per executed event: .*' /tmp/loadtest-logs.txt | tail -1 | sed 's/.*event: //' || echo "")

--- a/hack/loadtest-otel.yaml
+++ b/hack/loadtest-otel.yaml
@@ -1,64 +1,62 @@
-# Throwaway Jaeger all-in-one used only by the kind loadtests (hack/kind-*-loadtest.sh)
-# as an in-cluster OTLP sink for the engine's OpenTelemetry export. The engine is
-# pointed at svc `jaeger:4317` via `--set sharedConfig.env.SERVER_OTEL_COLLECTOR_URL`.
-# After a run the scripts export the collected traces (Jaeger JSON) as a CI artifact.
-# In-memory storage only — the cluster is torn down after every run.
+# In-cluster ClickStack OTel collector used only by the kind loadtests
+# (hack/kind-*-loadtest.sh) as the OTLP sink for the engine's OpenTelemetry export.
+# The engine is pointed at svc `otel-collector:4317` (in-cluster, plaintext); the
+# collector holds the ClickHouse Cloud credentials and ships spans there over TLS.
+# Credentials come from the `clickstack-otel` Secret the scripts create from GitHub
+# secrets. The cluster is torn down after every run.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jaeger
+  name: otel-collector
   labels:
-    app: jaeger
+    app: otel-collector
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: jaeger
+      app: otel-collector
   template:
     metadata:
       labels:
-        app: jaeger
+        app: otel-collector
     spec:
       containers:
-        - name: jaeger
-          image: jaegertracing/all-in-one:1.76.0
+        - name: otel-collector
+          image: clickhouse/clickstack-otel-collector:latest
           imagePullPolicy: IfNotPresent
-          env:
-            - name: COLLECTOR_OTLP_ENABLED
-              value: "true"
+          envFrom:
+            - secretRef:
+                name: clickstack-otel
           ports:
             - name: otlp-grpc
               containerPort: 4317
-            - name: query
-              containerPort: 16686
-            - name: admin
-              containerPort: 14269
+            - name: otlp-http
+              containerPort: 4318
           readinessProbe:
-            httpGet:
-              path: /
-              port: 14269
+            tcpSocket:
+              port: 4317
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: jaeger
+  name: otel-collector
   labels:
-    app: jaeger
+    app: otel-collector
 spec:
   selector:
-    app: jaeger
+    app: otel-collector
   ports:
     - name: otlp-grpc
       port: 4317
       targetPort: 4317
-    - name: query
-      port: 16686
-      targetPort: 16686
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Send loadtest traces to ClickStack instead of Jaegar exports.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)
