### PR TITLE
feat: add ingress support for hatchet-stack and hatchet-ha

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-07-27
+
+- Chart version bump only, to stay in lockstep with the `hatchet-stack` and `hatchet-ha` umbrella charts; no template changes in this release.
+
 ## [0.13.3] - 2026-07-17
 
 - Move the PodDisruptionBudget out of `deployment.yaml` into its own `pdb.yaml` template, and bump it from the removed `policy/v1beta1` API version to `policy/v1`. Setting `podDisruptionBudget` previously failed to install on Kubernetes 1.25+, where `policy/v1beta1` no longer exists.
@@ -117,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-api-0.13.3...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-api-0.13.4...HEAD
+[0.13.4]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-api-0.13.3...hatchet-api-0.13.4
 [0.13.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.13.3
 [0.13.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.13.2
 [0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-api-0.13.1

--- a/charts/hatchet-api/Chart.yaml
+++ b/charts/hatchet-api/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-api
 description: A Helm chart for deploying Hatchet API components on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.3
+version: 0.13.4
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-frontend/CHANGELOG.md
+++ b/charts/hatchet-frontend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-07-27
+
+- Chart version bump only, to stay in lockstep with the `hatchet-stack` and `hatchet-ha` umbrella charts; no template changes in this release.
+
 ## [0.13.3] - 2026-07-17
 
 - Move the PodDisruptionBudget out of `deployment.yaml` into its own `pdb.yaml` template, and bump it from the removed `policy/v1beta1` API version to `policy/v1`. Setting `podDisruptionBudget` previously failed to install on Kubernetes 1.25+, where `policy/v1beta1` no longer exists.
@@ -106,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-frontend-0.13.3...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-frontend-0.13.4...HEAD
+[0.13.4]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-frontend-0.13.3...hatchet-frontend-0.13.4
 [0.13.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.13.3
 [0.13.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.13.2
 [0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-frontend-0.13.1

--- a/charts/hatchet-frontend/Chart.yaml
+++ b/charts/hatchet-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-frontend
 description: A Helm chart for deploying a frontend static file server on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.3
+version: 0.13.4
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts

--- a/charts/hatchet-ha/CHANGELOG.md
+++ b/charts/hatchet-ha/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-07-27
+
+- Add `caddy.ingress` to expose the Hatchet dashboard through a Kubernetes Ingress that fronts the Caddy service (which already routes `/api/*` to the API and `/*` to the frontend). Disabled by default (`caddy.ingress.enabled: false`), so existing deployments are unaffected. When enabling it, set `caddy.address` to `":8080"` so Caddy accepts the ingress `Host` header and `caddy.service.type` to `ClusterIP` so no cloud load balancer is provisioned. Because the frontend assets use root-relative paths, the dashboard must be served at the root of a dedicated host.
+- Bump the bundled `hatchet-api` and `hatchet-frontend` subcharts to `0.13.4` (chart version bump only; no template changes).
+
 ## [0.13.3] - 2026-07-17
 
 - Add `caddy.address` to configure the Caddy site address (the top line of the generated Caddyfile). Defaults to `http://localhost:8080`, unchanged from previous releases, which serves only requests with `Host: localhost` and matches the documented `kubectl port-forward` workflow. Set it to `":8080"` to serve any `Host` instead, e.g. when fronting Caddy with an ingress, service mesh or VPN overlay such as Tailscale.
@@ -101,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2024-11-22
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-ha-0.13.3...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-ha-0.13.4...HEAD
+[0.13.4]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-ha-0.13.3...hatchet-ha-0.13.4
 [0.13.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.13.3
 [0.13.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.13.2
 [0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-ha-0.13.1

--- a/charts/hatchet-ha/Chart.lock
+++ b/charts/hatchet-ha/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.13.3
+  version: 0.13.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:0c7a1c0b0853f5ec8782803fc55a5eea85de18e888d52fddd5871dab58f6e93f
-generated: "2026-07-17T13:45:11.435137+02:00"
+digest: sha256:018a839b4ad0f3cdc4a0c83569b98a4ac633e3ef372335f4493ea50a544f9765
+generated: "2026-07-27T11:33:39.657453+02:00"

--- a/charts/hatchet-ha/Chart.yaml
+++ b/charts/hatchet-ha/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-ha
 description: A Helm chart for deploying Hatchet in a high-availability configuration
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.3
+version: 0.13.4
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -28,27 +28,27 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: api
   - name: "hatchet-api"
     condition: grpc.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: grpc
   - name: "hatchet-api"
     condition: controllers.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: controllers
   - name: "hatchet-api"
     condition: scheduler.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: scheduler
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-ha/README.md
+++ b/charts/hatchet-ha/README.md
@@ -141,6 +141,39 @@ Inherited by all backend services (`api`, `grpc`, `controllers`, `scheduler`).
 | `caddy.image.repository` | string | `"caddy"` | Caddy image repository. |
 | `caddy.image.tag` | string | `"2.7.6-alpine"` | Caddy image tag. |
 | `caddy.image.pullPolicy` | string | `"IfNotPresent"` | Caddy image pull policy. |
+| `caddy.ingress.enabled` | bool | `false` | Expose the Hatchet dashboard through an Ingress that fronts the Caddy service. |
+| `caddy.ingress.className` | string | _unset_ | IngressClass name (e.g. `nginx`). |
+| `caddy.ingress.host` | string | _unset_ | Host the dashboard is served at. Must be a dedicated host served at the root path. |
+| `caddy.ingress.path` | string | `"/"` | Ingress path. Keep as `/` because the frontend assets use root-relative paths and cannot be served under a sub-path. |
+| `caddy.ingress.pathType` | string | `"Prefix"` | Ingress `pathType`. |
+| `caddy.ingress.annotations` | object | `{}` | Annotations added to the Ingress. |
+| `caddy.ingress.tls` | array | _unset_ | TLS configuration passed through to the Ingress spec. |
+
+### Exposing the dashboard via Ingress
+
+The optional Caddy reverse proxy already routes `/api/*` to the API and `/*` to
+the frontend, so a single Ingress fronting the Caddy service exposes the whole
+dashboard. To serve it at `hatchet.example.com`:
+
+```yaml
+caddy:
+  enabled: true
+  # Accept the ingress Host header instead of only Host: localhost.
+  address: ":8080"
+  service:
+    # No cloud load balancer; the ingress controller fronts Caddy.
+    type: ClusterIP
+  ingress:
+    enabled: true
+    className: nginx
+    host: hatchet.example.com
+    path: "/"
+    pathType: Prefix
+```
+
+The frontend assets use root-relative paths (`/assets/...`, `/favicon.svg`), so
+the dashboard must be served at the **root of a dedicated host**; it cannot be
+mounted under a sub-path.
 
 ## License
 

--- a/charts/hatchet-ha/templates/ingress.yaml
+++ b/charts/hatchet-ha/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.caddy.enabled .Values.caddy.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  labels:
+{{- include "hatchet.labels" . | nindent 4 }}
+{{- with .Values.caddy.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.caddy.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+{{- with .Values.caddy.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.caddy.ingress.path | default "/" }}
+        pathType: {{ .Values.caddy.ingress.pathType | default "Prefix" }}
+        backend:
+          service:
+            name: caddy
+            port:
+              number: 8080
+{{- with .Values.caddy.ingress.host }}
+    host: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/hatchet-ha/values.schema.json
+++ b/charts/hatchet-ha/values.schema.json
@@ -102,6 +102,20 @@
           "properties": {
             "type": { "type": "string", "description": "Service type for the Caddy reverse proxy." }
           }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Ingress that fronts the Caddy service to expose the Hatchet dashboard.",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable the dashboard Ingress." },
+            "className": { "type": "string", "description": "IngressClass name (e.g. nginx)." },
+            "host": { "type": "string", "description": "Host the dashboard is served at. Must be a dedicated host served at the root path." },
+            "path": { "type": "string", "description": "Ingress path. Keep as \"/\" because the frontend assets use root-relative paths." },
+            "pathType": { "type": "string", "description": "Ingress pathType." },
+            "annotations": { "type": "object", "additionalProperties": true, "description": "Annotations added to the Ingress." },
+            "tls": { "type": "array", "description": "TLS configuration passed through to the Ingress spec.", "items": { "type": "object" } }
+          }
         }
       }
     }

--- a/charts/hatchet-ha/values.yaml
+++ b/charts/hatchet-ha/values.yaml
@@ -283,3 +283,23 @@ caddy:
     # Set to ClusterIP to front Caddy with your own ingress, service mesh or VPN
     # overlay instead of provisioning a cloud load balancer.
     type: LoadBalancer
+  # Expose the Hatchet dashboard through a Kubernetes Ingress that fronts the
+  # Caddy service (which already routes /api/* to the API and /* to the
+  # frontend). Disabled by default to preserve the port-forward workflow.
+  #
+  # When enabling this, also set caddy.address to ":8080" so Caddy accepts the
+  # ingress Host header, and set caddy.service.type to ClusterIP so no cloud
+  # load balancer is provisioned. Because the frontend assets use root-relative
+  # paths, the dashboard must be served at the root of a dedicated host, so
+  # leave ingress.path as "/".
+  ingress:
+    enabled: false
+    # className: nginx
+    # host: hatchet.example.com
+    path: "/"
+    pathType: "Prefix"
+    annotations: {}
+    # tls:
+    #   - hosts:
+    #       - hatchet.example.com
+    #     secretName: hatchet-dashboard-tls

--- a/charts/hatchet-stack/CHANGELOG.md
+++ b/charts/hatchet-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-07-27
+
+- Add `caddy.ingress` to expose the Hatchet dashboard through a Kubernetes Ingress that fronts the Caddy service (which already routes `/api/*` to the API and `/*` to the frontend). Disabled by default (`caddy.ingress.enabled: false`), so existing deployments are unaffected. When enabling it, set `caddy.address` to `":8080"` so Caddy accepts the ingress `Host` header and `caddy.service.type` to `ClusterIP` so no cloud load balancer is provisioned. Because the frontend assets use root-relative paths, the dashboard must be served at the root of a dedicated host.
+- Bump the bundled `hatchet-api` and `hatchet-frontend` subcharts to `0.13.4` (chart version bump only; no template changes).
+
 ## [0.13.3] - 2026-07-17
 
 - Add `caddy.address` to configure the Caddy site address (the top line of the generated Caddyfile). Defaults to `http://localhost:8080`, unchanged from previous releases, which serves only requests with `Host: localhost` and matches the documented `kubectl port-forward` workflow. Set it to `":8080"` to serve any `Host` instead, e.g. when fronting Caddy with an ingress, service mesh or VPN overlay such as Tailscale.
@@ -118,7 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 
-[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-stack-0.13.3...HEAD
+[Unreleased]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-stack-0.13.4...HEAD
+[0.13.4]: https://github.com/hatchet-dev/hatchet-charts/compare/hatchet-stack-0.13.3...hatchet-stack-0.13.4
 [0.13.3]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.13.3
 [0.13.2]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.13.2
 [0.13.1]: https://github.com/hatchet-dev/hatchet-charts/releases/tag/hatchet-stack-0.13.1

--- a/charts/hatchet-stack/Chart.lock
+++ b/charts/hatchet-stack/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-api
   repository: file://../hatchet-api
-  version: 0.13.3
+  version: 0.13.4
 - name: hatchet-frontend
   repository: file://../hatchet-frontend
-  version: 0.13.3
+  version: 0.13.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:d727993238012b3d359f53f29d06de8770366a46df2fb5860a48206cd0242951
-generated: "2026-07-17T13:45:02.636431+02:00"
+digest: sha256:ba4d6580e7f08989e147c0a52b5d72a82938a241af9a3948b4359cb5889364ad
+generated: "2026-07-27T11:33:30.954854+02:00"

--- a/charts/hatchet-stack/Chart.yaml
+++ b/charts/hatchet-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: hatchet-stack
 description: A Helm chart for deploying Hatchet on Kubernetes.
 type: application
 icon: https://hatchet.run/brand/logomark-white-bg.svg
-version: 0.13.3
+version: 0.13.4
 home: https://hatchet.run
 sources:
   - https://github.com/hatchet-dev/hatchet-charts
@@ -27,17 +27,17 @@ dependencies:
   - name: "hatchet-api"
     condition: api.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: api
   - name: "hatchet-api"
     condition: engine.enabled
     repository: "file://../hatchet-api"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: engine
   - name: "hatchet-frontend"
     condition: frontend.enabled
     repository: "file://../hatchet-frontend"
-    version: "0.13.3"
+    version: "0.13.4"
     alias: frontend
   - name: "postgresql"
     condition: postgres.enabled

--- a/charts/hatchet-stack/README.md
+++ b/charts/hatchet-stack/README.md
@@ -135,6 +135,39 @@ Inherited by all backend services (`api`, `engine`).
 | `caddy.image.repository` | string | `"caddy"` | Caddy image repository. |
 | `caddy.image.tag` | string | `"2.7.6-alpine"` | Caddy image tag. |
 | `caddy.image.pullPolicy` | string | `"IfNotPresent"` | Caddy image pull policy. |
+| `caddy.ingress.enabled` | bool | `false` | Expose the Hatchet dashboard through an Ingress that fronts the Caddy service. |
+| `caddy.ingress.className` | string | _unset_ | IngressClass name (e.g. `nginx`). |
+| `caddy.ingress.host` | string | _unset_ | Host the dashboard is served at. Must be a dedicated host served at the root path. |
+| `caddy.ingress.path` | string | `"/"` | Ingress path. Keep as `/` because the frontend assets use root-relative paths and cannot be served under a sub-path. |
+| `caddy.ingress.pathType` | string | `"Prefix"` | Ingress `pathType`. |
+| `caddy.ingress.annotations` | object | `{}` | Annotations added to the Ingress. |
+| `caddy.ingress.tls` | array | _unset_ | TLS configuration passed through to the Ingress spec. |
+
+### Exposing the dashboard via Ingress
+
+The optional Caddy reverse proxy already routes `/api/*` to the API and `/*` to
+the frontend, so a single Ingress fronting the Caddy service exposes the whole
+dashboard. To serve it at `hatchet.example.com`:
+
+```yaml
+caddy:
+  enabled: true
+  # Accept the ingress Host header instead of only Host: localhost.
+  address: ":8080"
+  service:
+    # No cloud load balancer; the ingress controller fronts Caddy.
+    type: ClusterIP
+  ingress:
+    enabled: true
+    className: nginx
+    host: hatchet.example.com
+    path: "/"
+    pathType: Prefix
+```
+
+The frontend assets use root-relative paths (`/assets/...`, `/favicon.svg`), so
+the dashboard must be served at the **root of a dedicated host**; it cannot be
+mounted under a sub-path.
 
 ## License
 

--- a/charts/hatchet-stack/templates/ingress.yaml
+++ b/charts/hatchet-stack/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.caddy.enabled .Values.caddy.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-dashboard
+  labels:
+{{- include "hatchet.labels" . | nindent 4 }}
+{{- with .Values.caddy.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.caddy.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+{{- with .Values.caddy.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.caddy.ingress.path | default "/" }}
+        pathType: {{ .Values.caddy.ingress.pathType | default "Prefix" }}
+        backend:
+          service:
+            name: caddy
+            port:
+              number: 8080
+{{- with .Values.caddy.ingress.host }}
+    host: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/hatchet-stack/values.schema.json
+++ b/charts/hatchet-stack/values.schema.json
@@ -100,6 +100,20 @@
           "properties": {
             "type": { "type": "string", "description": "Service type for the Caddy reverse proxy." }
           }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Ingress that fronts the Caddy service to expose the Hatchet dashboard.",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable the dashboard Ingress." },
+            "className": { "type": "string", "description": "IngressClass name (e.g. nginx)." },
+            "host": { "type": "string", "description": "Host the dashboard is served at. Must be a dedicated host served at the root path." },
+            "path": { "type": "string", "description": "Ingress path. Keep as \"/\" because the frontend assets use root-relative paths." },
+            "pathType": { "type": "string", "description": "Ingress pathType." },
+            "annotations": { "type": "object", "additionalProperties": true, "description": "Annotations added to the Ingress." },
+            "tls": { "type": "array", "description": "TLS configuration passed through to the Ingress spec.", "items": { "type": "object" } }
+          }
         }
       }
     }

--- a/charts/hatchet-stack/values.yaml
+++ b/charts/hatchet-stack/values.yaml
@@ -186,3 +186,23 @@ caddy:
     # Set to ClusterIP to front Caddy with your own ingress, service mesh or VPN
     # overlay instead of provisioning a cloud load balancer.
     type: LoadBalancer
+  # Expose the Hatchet dashboard through a Kubernetes Ingress that fronts the
+  # Caddy service (which already routes /api/* to the API and /* to the
+  # frontend). Disabled by default to preserve the port-forward workflow.
+  #
+  # When enabling this, also set caddy.address to ":8080" so Caddy accepts the
+  # ingress Host header, and set caddy.service.type to ClusterIP so no cloud
+  # load balancer is provisioned. Because the frontend assets use root-relative
+  # paths, the dashboard must be served at the root of a dedicated host, so
+  # leave ingress.path as "/".
+  ingress:
+    enabled: false
+    # className: nginx
+    # host: hatchet.example.com
+    path: "/"
+    pathType: "Prefix"
+    annotations: {}
+    # tls:
+    #   - hosts:
+    #       - hatchet.example.com
+    #     secretName: hatchet-dashboard-tls


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add support for serving the dashboard via an ingress.

Fixes https://github.com/hatchet-dev/hatchet/issues/4224

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
