### PR TITLE
feat(hatchet-api): add jobResources for the bootstrap Jobs

### DIFF
--- a/charts/hatchet-api/CHANGELOG.md
+++ b/charts/hatchet-api/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `jobResources`, applied to every container in the bootstrap Jobs (setup, seed, migration and `create-worker-token`, plus their `check-db-connection` init containers). These were the only pods in the chart with no way to set requests or limits, which blocked installs on clusters whose admission policies require them. Defaults to `{}`, so existing releases are unchanged.
+
 ## [0.15.0] - 2026-08-17
 
 - Update the default Hatchet image to [`v0.101.27`](https://github.com/hatchet-dev/hatchet/releases/tag/v0.101.27) for the API, setup, migration and seed Jobs.

--- a/charts/hatchet-api/README.md
+++ b/charts/hatchet-api/README.md
@@ -48,6 +48,7 @@ This chart ships a [`values.schema.json`](https://github.com/hatchet-dev/hatchet
 | `seedJob.image.pullPolicy` | string | `"IfNotPresent"` | Seed Job image pull policy. |
 | `quickstartJob.enabled` | bool | `true` | Enable the Job that generates cookie/encryption secrets via `hatchet-admin quickstart`. |
 | `workerTokenJob.enabled` | bool | `true` | Enable the Job that generates a worker API token. |
+| `jobResources` | object | `{}` | Compute resources applied to every container in the bootstrap Jobs (setup, seed, migration, `create-worker-token`, and their `check-db-connection` init containers). |
 | `retainFailedHooks` | bool | `true` | Retain failed Helm hook Jobs (e.g. the pre-upgrade migration hook) so logs survive for debugging. |
 
 ### Container runtime

--- a/charts/hatchet-api/templates/setup-job.yaml
+++ b/charts/hatchet-api/templates/setup-job.yaml
@@ -36,6 +36,10 @@ spec:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
         imagePullPolicy: {{ .Values.postgresImage.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         command: ['/bin/sh','-lc']
         args:
           - |
@@ -54,6 +58,10 @@ spec:
       - name: migration-job
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
@@ -127,6 +135,10 @@ spec:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
         imagePullPolicy: {{ .Values.postgresImage.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         command: ['/bin/sh','-lc']
         args:
           - |
@@ -146,6 +158,10 @@ spec:
       - name: migration-job
         image: "{{ .Values.migrationJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.migrationJob.image.tag) }}"
         imagePullPolicy: {{ .Values.migrationJob.image.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         securityContext:
           capabilities:
             add:
@@ -164,6 +180,10 @@ spec:
       - name: seed-job
         image: "{{ .Values.seedJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.seedJob.image.tag) }}"
         imagePullPolicy: {{ .Values.seedJob.image.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "quickstart", "--skip", "certs", "--skip", "keys"]
         securityContext:
@@ -186,6 +206,10 @@ spec:
       - name: setup-job
         image: "{{ .Values.setupJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.setupJob.image.tag) }}"
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "quickstart", "--namespace", "{{ .Release.Namespace }}", "--overwrite=false"]
         securityContext:
@@ -206,6 +230,10 @@ spec:
       - name: empty
         image: "alpine:3.14"
         command: ["sh", "-c", "echo 'No setup job configured'"]
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
 {{- end }}
 ---
 {{- if .Values.workerTokenJob.enabled }}
@@ -241,6 +269,10 @@ spec:
       - name: check-db-connection
         image: "{{ .Values.postgresImage.repository }}:{{ required "Please set a value for .Values.postgresImage.tag" .Values.postgresImage.tag }}"
         imagePullPolicy: {{ .Values.postgresImage.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         command: ['sh','-lc']
         args:
           - |
@@ -261,6 +293,10 @@ spec:
       - name: setup-worker-token
         image: "{{ .Values.setupJob.image.repository }}:{{ required "Please set a value for .Values.image.tag" (coalesce .Values.sharedConfig.image.tag .Values.setupJob.image.tag) }}"
         imagePullPolicy: {{ .Values.setupJob.image.pullPolicy }}
+        {{- with .Values.jobResources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         # this command requires read-write access on the hatchet-config configmap
         command: ["/hatchet/hatchet-admin", "k8s", "create-worker-token", "--namespace", "{{ .Release.Namespace }}"]
         securityContext:

--- a/charts/hatchet-api/tests/setup-job_test.yaml
+++ b/charts/hatchet-api/tests/setup-job_test.yaml
@@ -153,3 +153,82 @@ tests:
         documentSelector:
           path: kind
           value: Job
+
+  - it: omits resources on bootstrap containers by default
+    release:
+      upgrade: false
+    set:
+      workerTokenJob.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+        documentSelector:
+          path: kind
+          value: Job
+
+  - it: applies jobResources to the setup Job containers and init containers
+    release:
+      upgrade: false
+    set:
+      workerTokenJob.enabled: false
+      jobResources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+        documentSelector:
+          path: kind
+          value: Job
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+        documentSelector:
+          path: kind
+          value: Job
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: 256Mi
+        documentSelector:
+          path: kind
+          value: Job
+
+  - it: applies jobResources to the pre-upgrade migration hook
+    release:
+      upgrade: true
+    set:
+      jobResources:
+        requests:
+          cpu: 100m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+        documentSelector:
+          path: metadata.name
+          value: test-release-hatchet-api-migration
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 100m
+        documentSelector:
+          path: metadata.name
+          value: test-release-hatchet-api-migration
+
+  - it: applies jobResources to the create-worker-token Job
+    release:
+      upgrade: false
+    set:
+      jobResources:
+        limits:
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+        documentSelector:
+          path: spec.template.spec.containers[0].name
+          value: setup-worker-token

--- a/charts/hatchet-api/values.schema.json
+++ b/charts/hatchet-api/values.schema.json
@@ -102,6 +102,10 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "jobResources": {
+      "allOf": [{ "$ref": "#/$defs/resources" }],
+      "description": "Compute resources for every container in the bootstrap Jobs (setup, seed, migration, create-worker-token)."
+    },
     "commandline": {
       "type": "object",
       "description": "Container entrypoint command and arguments.",

--- a/charts/hatchet-api/values.yaml
+++ b/charts/hatchet-api/values.yaml
@@ -71,6 +71,12 @@ retainFailedHooks: true
 # keep finished Jobs around indefinitely (previous behaviour).
 jobTTLSecondsAfterFinished: 600
 
+# Compute resources applied to every container in the bootstrap Jobs (setup,
+# seed, migration and create-worker-token, plus their check-db-connection init
+# containers). Empty by default, which leaves the Jobs unbounded. Set this where
+# a LimitRange or an admission policy requires requests and limits on every pod.
+jobResources: {}
+
 env: {}
 
 deploymentEnvFrom:


### PR DESCRIPTION
## Problem

The bootstrap Jobs are the only pods in the chart with no way to set resource requests or limits. Every other workload has one: the Deployment has `resources`, the Cloud SQL sidecar has `cloudSQLSidecar.resources`.

That blocks installs on clusters whose admission policies require requests and limits on every pod. In our case a custom Checkov policy fails the rendered setup Job, and the only workarounds are to exempt the whole chart from policy checks or to stop using the bootstrap Jobs, both of which give up more than the problem is worth.

## Change

Adds a single `jobResources` value applied to every container in all three bootstrap Jobs:

- the setup Job: `check-db-connection`, `migration-job`, `seed-job`, and `setup-job` (or the `empty` placeholder when `quickstartJob.enabled` is false)
- the pre-upgrade migration hook Job
- the `create-worker-token` Job

One value rather than per-Job knobs, following the precedent of `jobTTLSecondsAfterFinished`, which likewise applies across the bootstrap Jobs. Happy to split it per Job if you would rather.

It defaults to `{}` and is rendered through `{{- with }}`, so nothing is emitted unless it is set and existing releases are unchanged.

## Verification

- `helm unittest charts/hatchet-api`: 12 passed, including 4 new cases covering the default-empty behaviour and propagation to the setup Job, the pre-upgrade hook, and the worker-token Job
- `./hack/test-schema.sh`: all assertions pass
- `./hack/test-ha-server-services.sh`: all assertions pass
- `helm template charts/hatchet-stack --set api.jobResources.limits.memory=777Mi` applies the limit to all 6 bootstrap containers rendered on install

One note while writing the tests: the `create-worker-token` Job is nested inside the `setupJob.enabled` conditional, so setting `setupJob.enabled: false` disables it too even when `workerTokenJob.enabled` is true. That looks unintended but I left it alone since it is out of scope here. Glad to send a separate PR if you agree it should be independent.